### PR TITLE
Separate message notifications and add click intents

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/MainActivity.kt
@@ -50,7 +50,7 @@ import com.pitchedapps.frost.dbflow.loadFbCookie
 import com.pitchedapps.frost.dbflow.loadFbTabs
 import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.facebook.FbCookie.switchUser
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.PROFILE_PICTURE_URL
 import com.pitchedapps.frost.fragments.WebFragment
 import com.pitchedapps.frost.utils.*
@@ -203,10 +203,10 @@ class MainActivity : BaseActivity(), SearchWebView.SearchContract,
                     tabsForEachView {
                         _, view ->
                         when (view.iicon) {
-                            FbTab.FEED.icon -> view.badgeText = feed
-                            FbTab.FRIENDS.icon -> view.badgeText = requests
-                            FbTab.MESSAGES.icon -> view.badgeText = messages
-                            FbTab.NOTIFICATIONS.icon -> view.badgeText = notifications
+                            FbItem.FEED.icon -> view.badgeText = feed
+                            FbItem.FRIENDS.icon -> view.badgeText = requests
+                            FbItem.MESSAGES.icon -> view.badgeText = messages
+                            FbItem.NOTIFICATIONS.icon -> view.badgeText = notifications
                         }
                     }
                 }
@@ -258,7 +258,7 @@ class MainActivity : BaseActivity(), SearchWebView.SearchContract,
                     identifier = -4L
                 }
                 onProfileChanged { _, profile, current ->
-                    if (current) launchWebOverlay(FbTab.PROFILE.url)
+                    if (current) launchWebOverlay(FbItem.PROFILE.url)
                     else when (profile.identifier) {
                         -2L -> {
                             val currentCookie = loadFbCookie(Prefs.userId)
@@ -292,25 +292,25 @@ class MainActivity : BaseActivity(), SearchWebView.SearchContract,
                 }
             }
             drawerHeader.setActiveProfile(Prefs.userId)
-            primaryFrostItem(FbTab.FEED_MOST_RECENT)
-            primaryFrostItem(FbTab.FEED_TOP_STORIES)
-            primaryFrostItem(FbTab.ACTIVITY_LOG)
+            primaryFrostItem(FbItem.FEED_MOST_RECENT)
+            primaryFrostItem(FbItem.FEED_TOP_STORIES)
+            primaryFrostItem(FbItem.ACTIVITY_LOG)
             divider()
-            primaryFrostItem(FbTab.PHOTOS)
-            primaryFrostItem(FbTab.GROUPS)
-            primaryFrostItem(FbTab.FRIENDS)
-            primaryFrostItem(FbTab.PAGES)
+            primaryFrostItem(FbItem.PHOTOS)
+            primaryFrostItem(FbItem.GROUPS)
+            primaryFrostItem(FbItem.FRIENDS)
+            primaryFrostItem(FbItem.PAGES)
             divider()
-            primaryFrostItem(FbTab.EVENTS)
-            primaryFrostItem(FbTab.BIRTHDAYS)
-            primaryFrostItem(FbTab.ON_THIS_DAY)
+            primaryFrostItem(FbItem.EVENTS)
+            primaryFrostItem(FbItem.BIRTHDAYS)
+            primaryFrostItem(FbItem.ON_THIS_DAY)
             divider()
-            primaryFrostItem(FbTab.NOTES)
-            primaryFrostItem(FbTab.SAVED)
+            primaryFrostItem(FbItem.NOTES)
+            primaryFrostItem(FbItem.SAVED)
         }
     }
 
-    fun Builder.primaryFrostItem(item: FbTab) = this.primaryItem(item.titleId) {
+    fun Builder.primaryFrostItem(item: FbItem) = this.primaryItem(item.titleId) {
         iicon = item.icon
         iconColor = Prefs.textColor.toLong()
         textColor = Prefs.textColor.toLong()
@@ -346,7 +346,7 @@ class MainActivity : BaseActivity(), SearchWebView.SearchContract,
     override fun searchOverlayDispose() {
         hiddenSearchView?.dispose()
         hiddenSearchView = null
-        searchView?.unBind { launchWebOverlay(FbTab.SEARCH.url); true }
+        searchView?.unBind { launchWebOverlay(FbItem.SEARCH.url); true }
         searchView = null
     }
 
@@ -376,7 +376,7 @@ class MainActivity : BaseActivity(), SearchWebView.SearchContract,
             }
         } else {
             if (searchView != null) searchOverlayDispose()
-            else menu.findItem(R.id.action_search).setOnMenuItemClickListener { _ -> launchWebOverlay(FbTab.SEARCH.url); true }
+            else menu.findItem(R.id.action_search).setOnMenuItemClickListener { _ -> launchWebOverlay(FbItem.SEARCH.url); true }
         }
         return true
     }
@@ -456,7 +456,7 @@ class MainActivity : BaseActivity(), SearchWebView.SearchContract,
     val currentFragment
         get() = supportFragmentManager.findFragmentByTag("android:switcher:${R.id.container}:${viewPager.currentItem}") as WebFragment
 
-    inner class SectionsPagerAdapter(fm: FragmentManager, val pages: List<FbTab>) : FragmentPagerAdapter(fm) {
+    inner class SectionsPagerAdapter(fm: FragmentManager, val pages: List<FbItem>) : FragmentPagerAdapter(fm) {
 
         override fun getItem(position: Int): Fragment {
             val fragment = WebFragment(pages[position], position)

--- a/app/src/main/kotlin/com/pitchedapps/frost/dbflow/CookiesDb.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/dbflow/CookiesDb.kt
@@ -4,7 +4,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.github.pwittchen.reactivenetwork.library.rx2.ReactiveNetwork
 import com.pitchedapps.frost.facebook.FACEBOOK_COM
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.logFrostAnswers
 import com.raizlabs.android.dbflow.annotation.ConflictAction
@@ -71,7 +71,7 @@ fun CookieModel.fetchUsername(callback: (String) -> Unit) {
         if (!yes) return@subscribe callback("")
         var result = ""
         try {
-            result = Jsoup.connect(FbTab.PROFILE.url)
+            result = Jsoup.connect(FbItem.PROFILE.url)
                     .cookie(FACEBOOK_COM, cookie)
                     .get().title()
             L.d("Fetch username found", result)

--- a/app/src/main/kotlin/com/pitchedapps/frost/dbflow/FbTabsDb.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/dbflow/FbTabsDb.kt
@@ -1,7 +1,7 @@
 package com.pitchedapps.frost.dbflow
 
 import android.content.Context
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.defaultTabs
 import com.pitchedapps.frost.utils.L
 import com.raizlabs.android.dbflow.annotation.Database
@@ -22,15 +22,15 @@ object FbTabsDb {
 }
 
 @Table(database = FbTabsDb::class, allFields = true)
-data class FbTabModel(@PrimaryKey var position: Int = -1, var tab: FbTab = FbTab.FEED) : BaseModel()
+data class FbTabModel(@PrimaryKey var position: Int = -1, var tab: FbItem = FbItem.FEED) : BaseModel()
 
-fun loadFbTabs(): List<FbTab> {
+fun loadFbTabs(): List<FbItem> {
     val tabs: List<FbTabModel>? = SQLite.select().from(FbTabModel::class).orderBy(FbTabModel_Table.position, true).queryList()
     if (tabs?.isNotEmpty() ?: false) return tabs!!.map { it.tab }
     L.d("No tabs; loading default")
     return defaultTabs()
 }
 
-fun List<FbTab>.saveAsync(c: Context) {
+fun List<FbItem>.saveAsync(c: Context) {
     mapIndexed { index, fbTab -> FbTabModel(index, fbTab) }.replace(c, FbTabsDb.NAME)
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
@@ -10,7 +10,7 @@ import com.pitchedapps.frost.web.FrostWebViewClient
 import com.pitchedapps.frost.web.FrostWebViewClientMenu
 import com.pitchedapps.frost.web.FrostWebViewCore
 
-enum class FbTab(@StringRes val titleId: Int, val icon: IIcon, relativeUrl: String, val webClient: ((webCore: FrostWebViewCore) -> FrostWebViewClient)? = null) {
+enum class FbItem(@StringRes val titleId: Int, val icon: IIcon, relativeUrl: String, val webClient: ((webCore: FrostWebViewCore) -> FrostWebViewClient)? = null) {
     ACTIVITY_LOG(R.string.activity_log, GoogleMaterial.Icon.gmd_list, "me/allactivity"),
     BIRTHDAYS(R.string.birthdays, GoogleMaterial.Icon.gmd_cake, "events/birthdays"),
     CHAT(R.string.chat, GoogleMaterial.Icon.gmd_chat, "buddylist"),
@@ -36,4 +36,4 @@ enum class FbTab(@StringRes val titleId: Int, val icon: IIcon, relativeUrl: Stri
     val url = "$FB_URL_BASE$relativeUrl"
 }
 
-fun defaultTabs(): List<FbTab> = listOf(FbTab.FEED, FbTab.MESSAGES, FbTab.NOTIFICATIONS, FbTab.MENU)
+fun defaultTabs(): List<FbItem> = listOf(FbItem.FEED, FbItem.MESSAGES, FbItem.NOTIFICATIONS, FbItem.MENU)

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/UsernameFetcher.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/UsernameFetcher.kt
@@ -17,7 +17,7 @@ object UsernameFetcher {
         thread {
             var name = ""
             try {
-                name = Jsoup.connect(FbTab.PROFILE.url)
+                name = Jsoup.connect(FbItem.PROFILE.url)
                         .cookie(FACEBOOK_COM, data.cookie)
                         .get().title()
                 L.d("User name found", name)

--- a/app/src/main/kotlin/com/pitchedapps/frost/fragments/WebFragment.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/fragments/WebFragment.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import ca.allanwang.kau.utils.withArguments
 import com.pitchedapps.frost.activities.MainActivity
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.FeedSort
 import com.pitchedapps.frost.utils.Prefs
 import com.pitchedapps.frost.web.FrostWebView
@@ -30,15 +30,15 @@ class WebFragment : Fragment() {
         const val REQUEST_TEXT_ZOOM = 17
         const val REQUEST_REFRESH = 99
 
-        operator fun invoke(data: FbTab, position: Int) = WebFragment().withArguments(
+        operator fun invoke(data: FbItem, position: Int) = WebFragment().withArguments(
                 ARG_URL to data.url,
                 ARG_POSITION to position,
                 ARG_URL_ENUM to when (data) {
                 //If is feed, check if sorting method is specified
-                    FbTab.FEED -> when (FeedSort(Prefs.feedSort)) {
+                    FbItem.FEED -> when (FeedSort(Prefs.feedSort)) {
                         FeedSort.DEFAULT -> data
-                        FeedSort.MOST_RECENT -> FbTab.FEED_MOST_RECENT
-                        FeedSort.TOP -> FbTab.FEED_TOP_STORIES
+                        FeedSort.MOST_RECENT -> FbItem.FEED_MOST_RECENT
+                        FeedSort.TOP -> FbItem.FEED_TOP_STORIES
                     }
                     else -> data
                 })
@@ -47,7 +47,7 @@ class WebFragment : Fragment() {
     //    val refresh: SwipeRefreshLayout by lazy { frostWebView.refresh }
     val web: FrostWebViewCore by lazy { frostWebView.web }
     val url: String by lazy { arguments.getString(ARG_URL) }
-    val urlEnum: FbTab by lazy { arguments.getSerializable(ARG_URL_ENUM) as FbTab }
+    val urlEnum: FbItem by lazy { arguments.getSerializable(ARG_URL_ENUM) as FbItem }
     val position: Int by lazy { arguments.getInt(ARG_POSITION) }
     lateinit var frostWebView: FrostWebView
     private var firstLoad = true

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
@@ -30,6 +30,12 @@ import org.jetbrains.anko.runOnUiThread
 
 /**
  * Created by Allan Wang on 2017-07-08.
+ *
+ * Logic for build notifications, scheduling notifications, and showing notifications
+ */
+
+/**
+ * Wrap the default builder with our icon and accent color
  */
 val Context.frostNotification: NotificationCompat.Builder
     get() = NotificationCompat.Builder(this, BuildConfig.APPLICATION_ID).apply {
@@ -38,6 +44,9 @@ val Context.frostNotification: NotificationCompat.Builder
         color = color(R.color.frost_notification_accent)
     }
 
+/**
+ * Assign global changes to the notification after it is built
+ */
 @Suppress("DEPRECATION")
         //The update feature is for Android O and seems to still be in beta
 fun Notification.frostConfig() = apply {
@@ -53,6 +62,7 @@ val NotificationCompat.Builder.withBigText: NotificationCompat.BigTextStyle
  * Created by Allan Wang on 2017-07-08.
  *
  * Custom target to set the content view and update a given notification
+ * 40dp is the size of the right avatar
  */
 class FrostNotificationTarget(val context: Context,
                               val notifId: Int,

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
@@ -66,6 +66,9 @@ class FrostNotificationTarget(val context: Context,
     }
 }
 
+internal const val FROST_NOTIFICATION_GROUP = "frost"
+internal const val FROST_MESSAGE_NOTIFICATION_GROUP = "frost_im"
+
 /**
  * Notification data holder
  */
@@ -76,11 +79,15 @@ data class NotificationContent(val data: CookieModel,
                                val text: String,
                                val timestamp: Long,
                                val profileUrl: String) {
-    fun createNotification(context: Context) {
+    fun createNotification(context: Context) = createNotification(context, FROST_NOTIFICATION_GROUP)
+
+    fun createMessageNotification(context: Context) = createNotification(context, FROST_MESSAGE_NOTIFICATION_GROUP)
+
+    private fun createNotification(context: Context, groupPrefix: String) {
         val intent = Intent(context, FrostWebActivity::class.java)
         intent.data = Uri.parse(href.formattedFbUrl)
         intent.putExtra(ARG_USER_ID, data.id)
-        val group = "frost_${data.id}"
+        val group = "${groupPrefix}_${data.id}"
         val pendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
         val notifBuilder = context.frostNotification
                 .setContentTitle(title ?: context.string(R.string.frost_name))

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/UpdateReceiver.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/UpdateReceiver.kt
@@ -13,6 +13,7 @@ import com.pitchedapps.frost.utils.Prefs
  */
 class UpdateReceiver : BroadcastReceiver() {
 
+    //todo check action warning
     override fun onReceive(context: Context, intent: Intent) {
         L.d("Frost has updated")
         context.scheduleNotifications(Prefs.notificationFreq) //Update notifications

--- a/app/src/main/kotlin/com/pitchedapps/frost/settings/Debug.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/settings/Debug.kt
@@ -10,7 +10,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.SettingsActivity
 import com.pitchedapps.frost.facebook.FACEBOOK_COM
 import com.pitchedapps.frost.facebook.FbCookie
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.USER_AGENT_BASIC
 import com.pitchedapps.frost.injectors.InjectorContract
 import com.pitchedapps.frost.injectors.JsActions
@@ -48,9 +48,9 @@ fun SettingsActivity.getDebugPrefs(): KPrefAdapterBuilder.() -> Unit = {
 
 }
 
-private enum class Debugger(val data: FbTab, val injector: InjectorContract?, vararg query: String) {
-    NOTIFICATIONS(FbTab.NOTIFICATIONS, null, "#notifications_list"),
-    SEARCH(FbTab.SEARCH, JsActions.FETCH_BODY);
+private enum class Debugger(val data: FbItem, val injector: InjectorContract?, vararg query: String) {
+    NOTIFICATIONS(FbItem.NOTIFICATIONS, null, "#notifications_list"),
+    SEARCH(FbItem.SEARCH, JsActions.FETCH_BODY);
 
     val query = if (query.isNotEmpty()) arrayOf(*query, "#root", "main", "body") else emptyArray()
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
@@ -25,7 +25,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.*
 import com.pitchedapps.frost.dbflow.CookieModel
 import com.pitchedapps.frost.facebook.FACEBOOK_COM
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.formattedFbUrl
 import java.io.IOException
 import java.util.*
@@ -74,7 +74,7 @@ fun Activity.launchIntroActivity(cookieList: ArrayList<CookieModel>)
         = launchNewTask(IntroActivity::class.java, cookieList, true)
 
 fun WebOverlayActivity.url(): String {
-    return intent.extras?.getString(ARG_URL) ?: FbTab.FEED.url
+    return intent.extras?.getString(ARG_URL) ?: FbItem.FEED.url
 }
 
 fun Context.materialDialogThemed(action: MaterialDialog.Builder.() -> Unit): MaterialDialog {

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebView.kt
@@ -11,7 +11,7 @@ import android.widget.FrameLayout
 import android.widget.ProgressBar
 import ca.allanwang.kau.utils.*
 import com.pitchedapps.frost.R
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.USER_AGENT_BASIC
 import com.pitchedapps.frost.utils.Prefs
 import com.pitchedapps.frost.utils.frostDownload
@@ -53,7 +53,7 @@ class FrostWebView @JvmOverloads constructor(
     }
 
     @SuppressLint("SetJavaScriptEnabled")
-    fun setupWebview(url: String, enum: FbTab? = null) {
+    fun setupWebview(url: String, enum: FbItem? = null) {
         with(web) {
             baseUrl = url
             baseEnum = enum
@@ -77,7 +77,7 @@ class FrostWebView @JvmOverloads constructor(
     //Some urls have postJavascript injections so make sure we load the base url
     override fun onRefresh() {
         when (web.baseUrl) {
-            FbTab.MENU.url -> web.loadBaseUrl(true)
+            FbItem.MENU.url -> web.loadBaseUrl(true)
             else -> web.reload(true)
         }
     }

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewCore.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewCore.kt
@@ -14,7 +14,7 @@ import ca.allanwang.kau.utils.circularReveal
 import ca.allanwang.kau.utils.fadeIn
 import ca.allanwang.kau.utils.fadeOut
 import ca.allanwang.kau.utils.isVisible
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.utils.Prefs
 import io.reactivex.Scheduler
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -41,7 +41,7 @@ class FrostWebViewCore @JvmOverloads constructor(
 
 
     var baseUrl: String? = null
-    var baseEnum: FbTab? = null //only viewpager items should pass the base enum
+    var baseEnum: FbItem? = null //only viewpager items should pass the base enum
     internal lateinit var frostWebClient: FrostWebViewClient
 
     init {

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/SearchWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/SearchWebView.kt
@@ -6,7 +6,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import ca.allanwang.kau.searchview.SearchItem
 import ca.allanwang.kau.utils.gone
-import com.pitchedapps.frost.facebook.FbTab
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.USER_AGENT_BASIC
 import com.pitchedapps.frost.injectors.JsAssets
 import com.pitchedapps.frost.injectors.JsBuilder
@@ -95,7 +95,7 @@ class SearchWebView(context: Context, val contract: SearchContract) : WebView(co
         }
 
     override fun reload() {
-        super.loadUrl(FbTab.SEARCH.url)
+        super.loadUrl(FbItem.SEARCH.url)
     }
 
     /**


### PR DESCRIPTION
* Message and general notifications are now grouped independently
* Both group messages have click events going to the message or notification pages respectively
* `FbTab` has been renamed to `FbItem` as it is a core component in all classes, not just for the tabs