### PR TITLE
Feature/scroll down on message thread

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/settings/Behaviour.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/settings/Behaviour.kt
@@ -31,6 +31,10 @@ fun SettingsActivity.getBehaviourPrefs(): KPrefAdapterBuilder.() -> Unit = {
         descRes = R.string.search_bar_desc
     }
 
+    checkbox(R.string.force_message_bottom, { Prefs.messageScrollToBottom }, { Prefs.messageScrollToBottom = it }) {
+        descRes = R.string.force_message_bottom_desc
+    }
+
     checkbox(R.string.exit_confirmation, { Prefs.exitConfirmation }, { Prefs.exitConfirmation = it }) {
         descRes = R.string.exit_confirmation_desc
     }

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Prefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Prefs.kt
@@ -105,6 +105,8 @@ object Prefs : KPref() {
 
     var notificationLights: Boolean by kpref("notification_lights", true)
 
+    var messageScrollToBottom: Boolean by kpref("message_scroll_to_bottom", false)
+
     /**
      * Cache like value to determine if user has or had pro
      * In most cases, [com.pitchedapps.frost.utils.iab.IS_FROST_PRO] should be looked at instead

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -14,6 +14,7 @@ import com.pitchedapps.frost.activities.WebOverlayActivity
 import com.pitchedapps.frost.facebook.FACEBOOK_COM
 import com.pitchedapps.frost.facebook.FB_URL_BASE
 import com.pitchedapps.frost.facebook.FbCookie
+import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.injectors.*
 import com.pitchedapps.frost.utils.*
 import com.pitchedapps.frost.utils.iab.IS_FROST_PRO
@@ -89,6 +90,8 @@ open class FrostWebViewClient(val webCore: FrostWebViewCore) : BaseWebViewClient
     }
 
     open internal fun onPageFinishedActions(url: String) {
+        if (url.startsWith("${FbItem.MESSAGES.url}/read/") && Prefs.messageScrollToBottom)
+            webCore.pageDown(true)
         injectAndFinish()
     }
 

--- a/app/src/main/res/values/strings_pref_behaviour.xml
+++ b/app/src/main/res/values/strings_pref_behaviour.xml
@@ -9,6 +9,10 @@
     <string name="overlay_full_screen_swipe_desc">Swipe right from anywhere on the overlaying web to close the browser. If disabled, only swiping from the left edge will move it.</string>
     <string name="viewpager_swipe">Viewpager Swipe</string>
     <string name="viewpager_swipe_desc">Allow swiping between the pages in the main view to switch tabs. By default, the swiping automatically stops when you long press on an item, such as the like button. Disabling this will prevent page swiping altogether.</string>
+    <string name="search_bar">Search Bar</string>
+    <string name="search_bar_desc">Enable the search bar instead of a search overlay</string>
+    <string name="force_message_bottom">Force Message Bottom</string>
+    <string name="force_message_bottom_desc">When loading a message thread, trigger a scroll to the bottom of the page rather than loading the page as is.</string>
     <string name="exit_confirmation">Exit Confirmation</string>
     <string name="exit_confirmation_desc">Show confirmation dialog before exiting the app</string>
     <string name="analytics">Analytics</string>

--- a/app/src/main/res/values/strings_pref_experimental.xml
+++ b/app/src/main/res/values/strings_pref_experimental.xml
@@ -5,8 +5,7 @@
     <string name="experimental_disclaimer_info">Experimental features may be unstable and may never make it to production. Use at your own risk, send feedback, and feel free to disable them if they don\'t work well.</string>
     <string name="experimental_by_default">Experimental by Default</string>
     <string name="experimental_by_default_desc">Feeling risky or just want to help with debugging? Checking this will enable future experimental functions be default.</string>
-    <string name="search_bar">Search Bar</string>
-    <string name="search_bar_desc">Enable the search bar instead of a search overlay</string>
+
     <string name="verbose_logging">Verbose Logging</string>
     <string name="verbose_logging_desc">Enable verbose logging to help with crash reports. Logging will only be sent once an error is encountered, so repeat the issue to notify the dev. This will automatically be disabled if the app restarts.</string>
     <string name="restart_frost">Restart Frost</string>

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -15,6 +15,9 @@
     <item text="Add hidden debugging options for certain views" />
     <item text="Separate IM and general notification groups" />
     <item text="Add click actions to group notifications. They will launch the message page or the notification page respectively" />
+    <item text="Add behaviour setting to force message threads to scroll to the bottom after loading." />
+    <item text="" />
+    <item text="" />
     <item text="" />
 	
 	<version title="v1.4.2"/>

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -13,8 +13,8 @@
 	<version title="Beta Updates"/>
     <item text="Create more robust IM notification fetcher with a timeout" />
     <item text="Add hidden debugging options for certain views" />
-    <item text="" />
-    <item text="" />
+    <item text="Separate IM and general notification groups" />
+    <item text="Add click actions to group notifications. They will launch the message page or the notification page respectively" />
     <item text="" />
 	
 	<version title="v1.4.2"/>

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3,6 +3,8 @@
 ## Beta Updates
 * Create more robust IM notification fetcher with a timeout
 * Add hidden debugging options for certain views
+* Separate IM and general notification groups
+* Add click actions to group notifications. They will launch the message page or the notification page respectively
 
 ## v1.4.2
 * Experimental: Add notifications for messages; report to me if this drains your battery

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,7 @@
 * Add hidden debugging options for certain views
 * Separate IM and general notification groups
 * Add click actions to group notifications. They will launch the message page or the notification page respectively
+* Add behaviour setting to force message threads to scroll to the bottom after loading.
 
 ## v1.4.2
 * Experimental: Add notifications for messages; report to me if this drains your battery


### PR DESCRIPTION
Some message threads have conversations that extend past the page width. The latest messages and the comment box therefore won't be visible.

This PR adds a toggle in the behaviour settings to allow an auto scroll after each page load (for notification threads only)