### PR TITLE
Reduce scontent trimming

### DIFF
--- a/app/src/main/assets/js/context_a.js
+++ b/app/src/main/assets/js/context_a.js
@@ -29,8 +29,8 @@ if (!window.hasOwnProperty('frost_context_a')) {
       var image = element.querySelector('[style*="background-image: url("]');
       if (!image) image = element.parentNode.querySelector('[style*="background-image: url("]');
       if (image) {
-        var imageUrl = window.getComputedStyle(image, null).backgroundImage.slice(5, -2);
-        console.log('Context image', imageUrl);
+        var imageUrl = window.getComputedStyle(image, null).backgroundImage.trim().slice(4, -1);
+        console.log('Context image: ' + imageUrl);
         if (typeof Frost !== 'undefined') Frost.loadImage(imageUrl, text);
         e.stopPropagation();
         e.preventDefault();

--- a/app/src/main/assets/js/context_a.min.js
+++ b/app/src/main/assets/js/context_a.min.js
@@ -12,8 +12,8 @@ var o=t.getAttribute("href")
 ;var n=t.parentNode.innerText,r=t.querySelector('[style*="background-image: url("]')
 ;if(r||(r=t.parentNode.querySelector('[style*="background-image: url("]')),
 r){
-var a=window.getComputedStyle(r,null).backgroundImage.slice(5,-2)
-;return console.log("Context image",a),
+var a=window.getComputedStyle(r,null).backgroundImage.trim().slice(4,-1)
+;return console.log("Context image: "+a),
 "undefined"!=typeof Frost&&Frost.loadImage(a,n),
 e.stopPropagation(),void e.preventDefault()
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/ImageActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/ImageActivity.kt
@@ -71,14 +71,13 @@ class ImageActivity : KauBaseActivity() {
             value.update(fab)
         }
 
-    val imageUrl: String
-        get() = intent.extras.getString(ARG_IMAGE_URL)
+    val imageUrl: String by lazy { intent.extras.getString(ARG_IMAGE_URL).trim('"') }
 
-    val text: String?
-        get() = intent.extras.getString(ARG_TEXT)
+    val text: String? by lazy { intent.extras.getString(ARG_TEXT) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        L.i("Displaying image $imageUrl")
         val layout = if (!text.isNullOrBlank()) R.layout.activity_image else R.layout.activity_image_textless
         setContentView(layout)
         container.setBackgroundColor(Prefs.bgColor.withMinAlpha(222))
@@ -166,8 +165,7 @@ class ImageActivity : KauBaseActivity() {
     }
 
     internal fun downloadImage() {
-        kauRequestPermissions(PERMISSION_WRITE_EXTERNAL_STORAGE) {
-            granted, _ ->
+        kauRequestPermissions(PERMISSION_WRITE_EXTERNAL_STORAGE) { granted, _ ->
             L.d("Download image callback granted: $granted")
             if (granted) {
                 doAsync {

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbUrlFormatter.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbUrlFormatter.kt
@@ -15,7 +15,7 @@ class FbUrlFormatter(url: String) {
     val cleaned: String
 
     init {
-        if (url.isNullOrBlank()) cleaned = ""
+        if (url.isBlank()) cleaned = ""
         else {
             var cleanedUrl = url
             discardable.forEach { cleanedUrl = cleanedUrl.replace(it, "", true) }
@@ -50,7 +50,8 @@ class FbUrlFormatter(url: String) {
 
     fun toLogList(): List<String> {
         val list = mutableListOf(cleaned)
-        queries.forEach { (k, v) -> list.add("- $k\t=\t$v") }
+        queries.forEach { (k, v) -> list.add("\n- $k\t=\t$v") }
+        list.add("\n\n${toString()}")
         return list
     }
 
@@ -60,7 +61,8 @@ class FbUrlFormatter(url: String) {
          * Taken from FaceSlim
          * https://github.com/indywidualny/FaceSlim/blob/master/app/src/main/java/org/indywidualni/fblite/util/Miscellany.java
          */
-        @JvmStatic val discardable = arrayOf(
+        @JvmStatic
+        val discardable = arrayOf(
                 "http://lm.facebook.com/l.php?u=",
                 "https://lm.facebook.com/l.php?u=",
                 "http://m.facebook.com/l.php?u=",
@@ -70,9 +72,11 @@ class FbUrlFormatter(url: String) {
                 "/video_redirect/?src="
         )
 
-        @JvmStatic val discardableQueries = arrayOf("ref", "refid")
+        @JvmStatic
+        val discardableQueries = arrayOf("ref", "refid")
 
-        @JvmStatic val decoder = mapOf(
+        @JvmStatic
+        val decoder = mapOf(
                 "%3C" to "<", "%3E" to ">", "%23" to "#", "%25" to "%",
                 "%7B" to "{", "%7D" to "}", "%7C" to "|", "%5C" to "\\",
                 "%5E" to "^", "%7E" to "~", "%5B" to "[", "%5D" to "]",

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -11,13 +11,19 @@
     <!--<version title="Beta Updates" />-->
 	
 	<version title="Beta Updates"/>
+	<item text="Prevent image loading from trimming too many characters" />
+	<item text="" />
+	<item text="" />
+	<item text="" />
+	<item text="" />
+	<item text="" />
+	
+	<version title="v1.4.12"/>
 	<item text="Fix new messages not showing" />
 	<item text="Fix theme for sharing and new messages" />
 	<item text="Prevent search bar settings from disabling itself if auto suggestions fail" />
 	<item text="Fix numerous crashes relating to search bar layouts" />
 	<item text="Add debugging for menu" />
-	<item text="" />
-	<item text="" />
 	
 	<version title="v1.4.11"/>
     <item text="Fix url loading bug and add option to launch urls in default browser (behaviour setting)" />

--- a/app/src/test/kotlin/com/pitchedapps/frost/facebook/FbUrlTest.kt
+++ b/app/src/test/kotlin/com/pitchedapps/frost/facebook/FbUrlTest.kt
@@ -14,31 +14,37 @@ class FbUrlTest {
         assertEquals(expected, fbUrl.toString(), "FbUrl Mismatch:\n${fbUrl.toLogList().joinToString("\n\t")}")
     }
 
-    @Test fun base() {
+    @Test
+    fun base() {
         val url = "https://touch.facebook.com/relative/?asdf=1234&hjkl=7890"
         assertFbFormat(url, url)
     }
 
-    @Test fun relative() {
+    @Test
+    fun relative() {
         val url = "/relative/?asdf=1234&hjkl=7890"
         assertFbFormat("$FB_URL_BASE${url.substring(1)}", url)
     }
 
-    @Test fun redirect() {
+    @Test
+    fun redirect() {
         assertFbFormat("${FB_URL_BASE}relative/?asdf=1234&hjkl=7890", "https://touch.facebook.com/l.php?u=${FB_URL_BASE}relative/&asdf=1234&hjkl=7890")
     }
 
-    @Test fun discard() {
+    @Test
+    fun discard() {
         val prefix = "$FB_URL_BASE?test=1234"
         val suffix = "&apple=notorange"
         assertFbFormat("$prefix$suffix", "$prefix&ref=hello$suffix")
     }
 
-    @Test fun doubleDash() {
+    @Test
+    fun doubleDash() {
         assertFbFormat("${FB_URL_BASE}relative", "$FB_URL_BASE/relative")
     }
 
-    @Test fun css() {
+    @Test
+    fun css() {
         val expected = "https://test.com?efg=hi&oh=bye&oe=apple"
         val orig = "https\\3a //test.com?efg\\3d hi\\26 oh\\3d bye\\26 oe\\3d apple"
         assertFbFormat(expected, orig)


### PR DESCRIPTION
The original slicing of 5 and -2 is to remove the quotation marks. However, it seems like in some cases, quotation marks don't exist, so the h in https and the last character are both removed.

We will now reduce slicing by 1 on each end, and trim quotation marks if they are found.