### PR TITLE
Fix/notification defaults

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbUrlFormatter.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbUrlFormatter.kt
@@ -30,7 +30,7 @@ class FbUrlFormatter(url: String) {
                 cleanedUrl = cleanedUrl.substring(0, qm)
             }
             discardableQueries.forEach { queries.remove(it) }
-            if (cleanedUrl.startsWith("#!/")) cleanedUrl = cleanedUrl.substring(2)
+            if (cleanedUrl.startsWith("#!")) cleanedUrl = cleanedUrl.substring(2)
             if (cleanedUrl.startsWith("/")) cleanedUrl = FB_URL_BASE + cleanedUrl.substring(1)
             cleanedUrl = cleanedUrl.replaceFirst(".facebook.com//", ".facebook.com/") //sometimes we are given a bad url
             L.v(null, "Formatted url from $url to $cleanedUrl")

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/DownloadService.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/DownloadService.kt
@@ -66,7 +66,7 @@ class DownloadService : IntentService("FrostVideoDownloader") {
                 .url(url)
                 .build()
 
-        notifBuilder = frostNotification.quiet
+        notifBuilder = frostNotification
         notifId = Math.abs(url.hashCode() + System.currentTimeMillis().toInt())
         val cancelIntent = PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT)
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/DownloadService.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/DownloadService.kt
@@ -28,6 +28,8 @@ import java.io.File
  *
  * Background file downloader
  * All we are given is a link and a mime type
+ *
+ * With reference to the <a href="https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/Progress.java">OkHttp3 sample</a>
  */
 class DownloadService : IntentService("FrostVideoDownloader") {
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
@@ -168,7 +168,11 @@ const val NOTIFICATION_PERIODIC_JOB = 7
  * returns false if an error occurs; true otherwise
  */
 fun Context.scheduleNotifications(minutes: Long): Boolean {
-    val scheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+    val scheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler?
+    if (scheduler == null) {
+        L.e("JobScheduler not found; cannot schedule notifications")
+        return false
+    }
     scheduler.cancel(NOTIFICATION_PERIODIC_JOB)
     if (minutes < 0L) return true
     val serviceComponent = ComponentName(this, NotificationService::class.java)
@@ -190,7 +194,11 @@ const val NOTIFICATION_JOB_NOW = 6
  * Run notification job right now
  */
 fun Context.fetchNotifications(): Boolean {
-    val scheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler? ?: return false
+    val scheduler = getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler?
+    if (scheduler == null) {
+        L.e("JobScheduler not found")
+        return false
+    }
     val serviceComponent = ComponentName(this, NotificationService::class.java)
     val builder = JobInfo.Builder(NOTIFICATION_JOB_NOW, serviceComponent)
             .setMinimumLatency(0L)

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationService.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationService.kt
@@ -124,11 +124,11 @@ class NotificationService : JobService() {
         val prevLatestEpoch = prevNotifTime.epoch
         L.v("Notif Prev Latest Epoch $prevLatestEpoch")
         var newLatestEpoch = prevLatestEpoch
-        unreadNotifications.forEachIndexed unread@ { index, elem ->
+        unreadNotifications.forEach unread@ { elem ->
             val notif = parseNotification(data, elem) ?: return@unread
             L.v("Notif timestamp ${notif.timestamp}")
             if (notif.timestamp <= prevLatestEpoch) return@unread
-            NotificationType.GENERAL.createNotification(this, notif, index == 0)
+            NotificationType.GENERAL.createNotification(this, notif, notifCount == 0)
             if (notif.timestamp > newLatestEpoch)
                 newLatestEpoch = notif.timestamp
             notifCount++
@@ -181,11 +181,11 @@ class NotificationService : JobService() {
         val prevLatestEpoch = prevNotifTime.epochIm
         L.v("Notif Prev Latest Im Epoch $prevLatestEpoch")
         var newLatestEpoch = prevLatestEpoch
-        unreadNotifications.forEachIndexed unread@ { index, elem ->
+        unreadNotifications.forEach unread@ { elem ->
             val notif = parseMessageNotification(data, elem) ?: return@unread
             L.v("Notif im timestamp ${notif.timestamp}")
             if (notif.timestamp <= prevLatestEpoch) return@unread
-            NotificationType.MESSAGE.createNotification(this, notif, index == 0)
+            NotificationType.MESSAGE.createNotification(this, notif, notifCount == 0)
             if (notif.timestamp > newLatestEpoch)
                 newLatestEpoch = notif.timestamp
             notifCount++

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Downloader.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Downloader.kt
@@ -1,162 +1,38 @@
 package com.pitchedapps.frost.utils
 
-import android.app.Notification
-import android.app.PendingIntent
+import android.app.DownloadManager
 import android.content.Context
-import android.content.Intent
-import android.support.v4.app.NotificationCompat
-import android.support.v4.app.NotificationManagerCompat
-import android.support.v4.content.FileProvider
+import android.content.Context.DOWNLOAD_SERVICE
+import android.net.Uri
+import android.os.Environment
+import android.webkit.URLUtil
 import ca.allanwang.kau.permissions.PERMISSION_WRITE_EXTERNAL_STORAGE
 import ca.allanwang.kau.permissions.kauRequestPermissions
-import ca.allanwang.kau.utils.copyFromInputStream
-import ca.allanwang.kau.utils.string
-import com.pitchedapps.frost.BuildConfig
-import com.pitchedapps.frost.R
-import com.pitchedapps.frost.services.DownloadService
-import com.pitchedapps.frost.services.frostNotification
-import com.pitchedapps.frost.services.getNotificationPendingCancelIntent
-import com.pitchedapps.frost.services.quiet
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.ResponseBody
-import okio.*
-import org.jetbrains.anko.AnkoAsyncContext
-import org.jetbrains.anko.startService
-import java.io.File
-import java.io.IOException
-import java.lang.ref.WeakReference
+import com.pitchedapps.frost.dbflow.loadFbCookie
+
 
 /**
  * Created by Allan Wang on 2017-08-04.
  *
- * With reference to the <a href="https://github.com/square/okhttp/blob/master/samples/guide/src/main/java/okhttp3/recipes/Progress.java">OkHttp3 sample</a>
- *
- * TODO delete this file; we've moved to our downloader service for now and will create our own player soon
+ * With reference to <a href="https://stackoverflow.com/questions/33434532/android-webview-download-files-like-browsers-do">Stack Overflow</a>
  */
-fun Context.frostDownload(url: String) {
+fun Context.frostDownload(url: String, userAgent: String, contentDisposition: String, mimeType: String, contentLength: Long) {
     L.d("Received download request", "Download $url")
     kauRequestPermissions(PERMISSION_WRITE_EXTERNAL_STORAGE) { granted, _ ->
-        if (granted)
-//            doAsync { frostDownloadImpl(url, type) }
-            startService<DownloadService>(DownloadService.EXTRA_URL to url)
-    }
-}
+        if (!granted) return@kauRequestPermissions
 
-private const val MAX_PROGRESS = 1000
-//private val DOWNLOAD_GROUP: String? = null
-private const val DOWNLOAD_GROUP = "frost_downloads"
+        val request = DownloadManager.Request(Uri.parse(url))
 
-private enum class DownloadType(val downloadingRes: Int, val downloadedRes: Int) {
-    VIDEO(R.string.downloading_video, R.string.downloaded_video),
-    FILE(R.string.downloading_file, R.string.downloaded_file);
-
-    fun getPendingIntent(context: Context, file: File): PendingIntent {
-        val uri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
-        val type = context.contentResolver.getType(uri)
-        L.d("DownloadType: retrieved pending intent - $uri $type")
-        val intent = Intent(Intent.ACTION_VIEW, uri)
-                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                .setDataAndType(uri, type)
-        return PendingIntent.getActivity(context, 0, intent, 0)
-    }
-}
-
-private fun AnkoAsyncContext<Context>.frostDownloadImpl(url: String, type: DownloadType) {
-    L.d("Starting download request")
-    val notifId = Math.abs(url.hashCode() + System.currentTimeMillis().toInt())
-    var notifBuilderAttempt: NotificationCompat.Builder? = null
-    weakRef.get()?.apply {
-        notifBuilderAttempt = frostNotification.quiet
-                .setContentTitle(string(type.downloadingRes))
-                .setCategory(Notification.CATEGORY_PROGRESS)
-                .setWhen(System.currentTimeMillis())
-                .setProgress(MAX_PROGRESS, 0, false)
-                .setOngoing(true)
-                .addAction(R.drawable.ic_action_cancel, string(R.string.kau_cancel), getNotificationPendingCancelIntent(DOWNLOAD_GROUP, notifId))
-                .setGroup(DOWNLOAD_GROUP)
-    }
-    val notifBuilder = notifBuilderAttempt ?: return
-    notifBuilder.show(weakRef, notifId)
-
-    val request: Request = Request.Builder()
-            .url(url)
-            .tag(url)
-            .build()
-
-    var client: OkHttpClient? = null
-    client = OkHttpClient.Builder()
-            .addNetworkInterceptor { chain ->
-                val original = chain.proceed(chain.request())
-                return@addNetworkInterceptor original.newBuilder().body(ProgressResponseBody(original.body()!!) { bytesRead, contentLength, done ->
-                    //cancel request if context reference is now invalid
-                    if (weakRef.get() == null) {
-                        client?.cancel(url)
-                    }
-                    val ctx = weakRef.get() ?: return@ProgressResponseBody client?.cancel(url) ?: Unit
-                    val percentage = bytesRead.toFloat() / contentLength.toFloat() * MAX_PROGRESS
-                    L.v("Download request progress: $percentage")
-                    notifBuilder.setProgress(MAX_PROGRESS, percentage.toInt(), false)
-                    if (done) {
-                        notifBuilder.setFinished(ctx, type)
-                        L.d("Download request finished")
-                    }
-                    notifBuilder.show(weakRef, notifId)
-                }).build()
-            }
-            .build()
-    client.newCall(request).execute().use { response ->
-        if (!response.isSuccessful) throw IOException("Unexpected code $response")
-        val stream = response.body()?.byteStream()
-        if (stream != null) {
-            val destination = createMediaFile(".mp4")
-            destination.copyFromInputStream(stream)
-            weakRef.get()?.apply {
-                notifBuilder.setContentIntent(type.getPendingIntent(this, destination))
-                notifBuilder.show(weakRef, notifId)
-            }
-        }
-    }
-}
-
-private fun NotificationCompat.Builder.setFinished(context: Context, type: DownloadType)
-        = setContentTitle(context.string(type.downloadedRes))
-        .setProgress(0, 0, false).setOngoing(false).setAutoCancel(true)
-        .apply { mActions.clear() }
-
-private fun OkHttpClient.cancel(url: String) {
-    val call = dispatcher().runningCalls().firstOrNull { it.request().tag() == url }
-    if (call != null && !call.isCanceled) call.cancel()
-}
-
-private fun NotificationCompat.Builder.show(weakRef: WeakReference<Context>, notifId: Int) {
-    val c = weakRef.get() ?: return
-    NotificationManagerCompat.from(c).notify(DOWNLOAD_GROUP, notifId, build())
-}
-
-private class ProgressResponseBody(
-        val responseBody: ResponseBody,
-        val listener: (bytesRead: Long, contentLength: Long, done: Boolean) -> Unit) : ResponseBody() {
-
-    private val bufferedSource: BufferedSource by lazy { Okio.buffer(source(responseBody.source())) }
-
-    override fun contentLength(): Long = responseBody.contentLength()
-
-    override fun contentType(): MediaType? = responseBody.contentType()
-
-    override fun source(): BufferedSource = bufferedSource
-
-    private fun source(source: Source): Source = object : ForwardingSource(source) {
-
-        private var totalBytesRead = 0L
-
-        override fun read(sink: Buffer?, byteCount: Long): Long {
-            val bytesRead = super.read(sink, byteCount)
-            // read() returns the number of bytes read, or -1 if this source is exhausted.
-            totalBytesRead += if (bytesRead != -1L) bytesRead else 0
-            listener(totalBytesRead, responseBody.contentLength(), bytesRead == -1L)
-            return bytesRead
-        }
+        request.setMimeType(mimeType)
+        val cookie = loadFbCookie(Prefs.userId) ?: return@kauRequestPermissions
+        request.addRequestHeader("cookie", cookie.cookie)
+        request.addRequestHeader("User-Agent", userAgent)
+        request.setDescription("Downloading file...")
+        request.setTitle(URLUtil.guessFileName(url, contentDisposition, mimeType))
+        request.allowScanningByMediaScanner()
+        request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, "Frost/" + URLUtil.guessFileName(url, contentDisposition, mimeType))
+        val dm = getSystemService(DOWNLOAD_SERVICE) as DownloadManager
+        dm.enqueue(request)
     }
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebView.kt
@@ -70,7 +70,7 @@ class FrostWebView @JvmOverloads constructor(
             webChromeClient = FrostChromeClient(this)
             addJavascriptInterface(FrostJSI(this), "Frost")
             setBackgroundColor(Color.TRANSPARENT)
-            setDownloadListener { downloadUrl, _, _, _, _ -> context.frostDownload(downloadUrl) }
+            setDownloadListener(context::frostDownload)
         }
     }
 

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -12,8 +12,8 @@
 	
 	<version title="Beta Updates"/>
 	<item text="Add default download manager to download all files" />
-	<item text="" />
-	<item text="" />
+	<item text="Limit notification sounds when multiple notifications come in" />
+	<item text="Check that job scheduler exists before scheduling notifications" />
 	<item text="" />
 	
 	<version title="v1.5.1"/>

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -11,6 +11,12 @@
     <!--<version title="Beta Updates" />-->
 	
 	<version title="Beta Updates"/>
+	<item text="Add default download manager to download all files" />
+	<item text="" />
+	<item text="" />
+	<item text="" />
+	
+	<version title="v1.5.1"/>
 	<item text="Release day is here!" />
 	<item text="Add full support for messaging in overlays. We will dynamically launch new overlays when required to." />
 	<item text="Prevent bad messenger intent from launching" />
@@ -19,10 +25,6 @@
 	<item text="Ensure that bottom bar layout does not hide the web content" />
 	<item text="Add option to share external links to Frost" />
 	<item text="Trigger notification service on each app start" />
-	<item text="" />
-	<item text="" />
-	<item text="" />
-	<item text="" />
 	
 	<version title="v1.4.13"/>
 	<item text="Prevent image loading from trimming too many characters" />

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Beta Updates
+* Add default download manager to download all files
+
+## v1.5.1
 * Release day is here!
 * Add full support for messaging in overlays. We will dynamically launch new overlays when required to.
 * Prevent bad messenger intent from launching

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,6 +8,7 @@
 * Add contextual menu items. Easily go to your full list of notifications or messages from the overlay.
 * Ensure that bottom bar layout does not hide the web content
 * Add option to share external links to Frost
+* Trigger notification service on each app start
 
 ## v1.4.13
 * Prevent image loading from trimming too many characters


### PR DESCRIPTION
Notification defaults (sound, vibration, lights) were originally added to each notification, but it overlaps when there are multiple overlaps sent at a time.

We will resolve this by removing defaults in basic notification creations, and add them manually when needed.

This will only occur on the first notification send, and on summary notifications