### PR TITLE
Use jackson-module-kotlin to improve data class mapping

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -219,6 +219,7 @@ dependencies {
     kapt "com.github.bumptech.glide:compiler:${kau.glide}"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:${JACKSON}"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${JACKSON}"
 
     //noinspection GradleDependency
     releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${LEAK_CANARY}"

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/requests/Menu.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/requests/Menu.kt
@@ -96,11 +96,6 @@ data class MenuData(
     val footer: MenuFooter = MenuFooter()
 ) {
 
-    @JsonCreator
-    constructor(
-        @JsonProperty("data") data: List<MenuHeader>?
-    ) : this(data ?: emptyList(), MenuFooter())
-
     fun flatMapValid(): List<MenuItemData> {
         val items = mutableListOf<MenuItemData>()
         data.forEach {
@@ -126,16 +121,6 @@ data class MenuHeader(
     val visible: List<MenuItem> = emptyList(),
     val all: List<MenuItem> = emptyList()
 ) : MenuItemData {
-
-    @JsonCreator
-    constructor(
-        @JsonProperty("id") id: String?,
-        @JsonProperty("header") header: String?,
-        @JsonProperty("visible") visible: List<MenuItem>?,
-        @JsonProperty("all") all: List<MenuItem>?,
-        @JsonProperty("fake") fake: Boolean?
-    ) : this(id, header, visible ?: emptyList(), all ?: emptyList())
-
     override val isValid: Boolean
         get() = !header.isNullOrBlank()
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/requests/Menu.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/requests/Menu.kt
@@ -19,11 +19,11 @@ package com.pitchedapps.frost.facebook.requests
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.MapperFeature
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.pitchedapps.frost.facebook.FB_URL_BASE
 import com.pitchedapps.frost.facebook.formattedFbUrl
 import com.pitchedapps.frost.utils.L
+import com.pitchedapps.frost.utils.objectMapper
 import okhttp3.Call
 import org.apache.commons.text.StringEscapeUtils
 import org.jsoup.Jsoup
@@ -54,11 +54,8 @@ fun parseMenu(call: Call): MenuData? {
 
     jsonString = "{ \"data\" : [${StringEscapeUtils.unescapeEcmaScript(jsonString)}"
 
-    val mapper = ObjectMapper()
-        .disable(MapperFeature.AUTO_DETECT_SETTERS)
-
     return try {
-        val data = mapper.readValue(jsonString, MenuData::class.java)
+        val data = objectMapper.readValue<MenuData>(jsonString)
 
         // parse footer content
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/ObjectMapper.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/ObjectMapper.kt
@@ -1,0 +1,5 @@
+package com.pitchedapps.frost.utils
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+val objectMapper = jacksonObjectMapper()


### PR DESCRIPTION
Problem: Out of the box jackson has problems finding data class getters/settters
jackson-module-kotlin improves jacksons ability to properly map data classes.
