### PR TITLE
Obfuscate window tags for JS injection

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
@@ -18,6 +18,7 @@ package com.pitchedapps.frost
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
@@ -62,6 +63,18 @@ class FrostApp : Application() {
 //    }
 
 //    lateinit var refWatcher: RefWatcher
+
+    init {
+        instance = this
+    }
+
+    companion object {
+        private lateinit var instance: FrostApp
+
+        fun applicationContext() : Context {
+            return instance.applicationContext
+        }
+    }
 
     private fun FlowConfig.Builder.withDatabase(name: String, klass: KClass<*>) =
         addDatabaseConfig(

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
@@ -115,7 +115,7 @@ private object TagObfuscator {
         val deviceId = Settings.Secure.getString(
                 FrostApp.applicationContext().contentResolver,
                 Settings.Secure.ANDROID_ID)
-        Random(deviceId.toLong(16))
+        Random(deviceId.dropLast(1).toLong(16))
     }
 
     private val prefix : String by lazy {


### PR DESCRIPTION
An attempt to help debug/fix #1504. It might be the case that FB detects Frost manipulating the DOM by scanning for the tag that the app leaves in the window DOM object. To make this detection harder or maybe even impossible this patch obfuscates said tags, using the device ID as a reproducible seed for the RNG. 

Sadly, the device ID seems to be the only constant that doesn't require the device to be a phone or have Google Services/microG installed. If anyone has a better idea for an RNG seed I'm open to any and all suggestions.

Also, in order to obtain the device ID, I needed access to the application context. If there's a more elegant way to obtain it than to put a singleton companion object into the FrostApp class, please let me know.