### PR TITLE
Disable click launches from notification page

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -68,6 +68,11 @@ open class FrostWebViewClient(val web: FrostWebView) : BaseWebViewClient() {
     private val refresh: SendChannel<Boolean> = web.parent.refreshChannel
     private val isMain = web.parent.baseEnum != null
 
+    override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
+        v { "History $url" }
+        super.doUpdateVisitedHistory(view, url, isReload)
+    }
+
     protected inline fun v(crossinline message: () -> Any?) = L.v { "web client: ${message()}" }
 
     override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -6,10 +6,15 @@
     <item text="" />
     -->
 
+    <version title="v2.4.1" />
+    <item text="Notification tab will keep first page in the same window; fixes marking notifications as read" />
+    <item text="" />
+    <item text="" />
+    <item text="" />
+
     <version title="v2.4.0" />
     <item text="Removed request services, which potentially caused phishing warnings." />
     <item text="Save images with the correct extensions." />
-    <item text="" />
 
     <version title="v2.3.2" />
     <item text="Disable auto feed refresh by default and add setting to re-enable it" />

--- a/app/src/web/ts/click_a.ts
+++ b/app/src/web/ts/click_a.ts
@@ -42,7 +42,10 @@
     type EventHandler = (e: Event, target: HTMLElement) => Boolean
 
     const _frostGeneral: EventHandler = (e, target) => {
-        // Notifications are two layers under
+        // We now disable clicks for the main notification page
+        if (document.getElementById("notifications_list")) {
+            return false
+        }
         const url = _parentUrl(target, 2);
         return Frost.loadUrl(url);
     };


### PR DESCRIPTION
Fixes #1547 

Due to implementation, launching urls in a new tab stops the event, which includes marking an item as read. Given that the content changes via js, shouldOverrideUrl is also not triggered. The only workaround I can think of is listening to `doUpdateVisitedHistory` changes and go back on a change, but that won't be efficient.

It is also nice to keep loads inline, because it's faster to load in the same window, and people will often transition between the notification list and the first page of a notification. Some of the notifications cannot be loaded in a new page anyways, so this makes everything consistent 