### PR TITLE
Fix auth

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/StartActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/StartActivity.kt
@@ -70,9 +70,9 @@ class StartActivity : KauBaseActivity() {
             showInvalidWebView()
         }
 
-        val authDefer = BiometricUtils.authenticate(this@StartActivity)
         launch {
             try {
+                val authDefer = BiometricUtils.authenticate(this@StartActivity)
                 FbCookie.switchBackUser()
                 val cookies = ArrayList(cookieDao.selectAll())
                 L.i { "Cookies loaded at time ${System.currentTimeMillis()}" }

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
@@ -87,6 +87,7 @@ import com.pitchedapps.frost.fragments.BaseFragment
 import com.pitchedapps.frost.fragments.WebFragment
 import com.pitchedapps.frost.services.scheduleNotificationsFromPrefs
 import com.pitchedapps.frost.utils.ACTIVITY_SETTINGS
+import com.pitchedapps.frost.utils.BiometricUtils
 import com.pitchedapps.frost.utils.EXTRA_COOKIES
 import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.MAIN_TIMEOUT_DURATION
@@ -521,7 +522,9 @@ abstract class BaseMainActivity : BaseActivity(), MainActivityContract,
         lastAccessTime = System.currentTimeMillis() // precaution to avoid loops
         controlWebview?.resumeTimers()
         launch {
+            val authDefer = BiometricUtils.authenticate(this@BaseMainActivity)
             FbCookie.switchBackUser()
+            authDefer.await()
             if (shouldReload && Prefs.autoRefreshFeed) {
                 refreshAll()
             }

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/WebOverlayActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/WebOverlayActivity.kt
@@ -224,10 +224,11 @@ abstract class WebOverlayActivityBase(private val userAgent: String = USER_AGENT
         with(web) {
             userAgentString = userAgent
             Prefs.prevId = Prefs.userId
-            val authDefer = BiometricUtils.authenticate(this@WebOverlayActivityBase)
             launch {
-                if (userId != Prefs.userId)
+                val authDefer = BiometricUtils.authenticate(this@WebOverlayActivityBase)
+                if (userId != Prefs.userId) {
                     FbCookie.switchUser(userId)
+                }
                 authDefer.await()
                 reloadBase(true)
                 if (Showcase.firstWebOverlay) {

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostUrlOverlayValidator.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostUrlOverlayValidator.kt
@@ -79,7 +79,7 @@ fun FrostWebView.requestWebOverlay(url: String): Boolean {
     if (!Prefs.overlayEnabled) return false
     if (context is WebOverlayActivityBase) {
         val shouldUseDesktop = url.isFacebookUrl
-        //already overlay; manage user agent
+        // already overlay; manage user agent
         if (userAgentString != USER_AGENT_DESKTOP_CONST && shouldUseDesktop) {
             L._i { "Switch to desktop agent overlay" }
             context.launchWebOverlayDesktop(url)

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -1,5 +1,5 @@
 v2.4.1
 
-* Convert facebook desktop urls to mobile ones
+* Add better support for mobile url conversions
 * Notification tab will keep first page in the same window; fixes marking notifications as read
 * Fix nav and status bar icon colors for custom themes (Android O+)

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -3,3 +3,4 @@ v2.4.1
 * Add better support for mobile url conversions
 * Notification tab will keep first page in the same window; fixes marking notifications as read
 * Fix nav and status bar icon colors for custom themes (Android O+)
+* Fix biometric prompt, and prompt on activity resume

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -10,7 +10,7 @@
     <item text="Add better support for mobile url conversions" />
     <item text="Notification tab will keep first page in the same window; fixes marking notifications as read" />
     <item text="Fix nav and status bar icon colors for custom themes (Android O+)" />
-    <item text="" />
+    <item text="Fix biometric prompt, and prompt on activity resume" />
     <item text="" />
 
     <version title="v2.4.0" />

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v2.4.1
-* Convert facebook desktop urls to mobile ones
+* Add better support for mobile url conversions
 * Notification tab will keep first page in the same window; fixes marking notifications as read
 * Fix nav and status bar icon colors for custom themes (Android O+)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,7 @@
 * Add better support for mobile url conversions
 * Notification tab will keep first page in the same window; fixes marking notifications as read
 * Fix nav and status bar icon colors for custom themes (Android O+)
+* Fix biometric prompt, and prompt on activity resume
 
 ## v2.4.0
 * Removed request services, which potentially caused phishing warnings.


### PR DESCRIPTION
Resolves #1557 

#1535 was not the right approach, as it seems to conflict with pending animations. We instead add a cancellation listener to ensure that responses do not occur after a saved state.

Also adding to main activity onResume as the main activity is often retained in memory. We will keep it in start activity too since we can run some background operations during the prompt