### PR TITLE
Fix backstack 

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
@@ -211,10 +211,7 @@ class FrostWebView @JvmOverloads constructor(
     }
 
     override fun destroy() {
-        val parent = getParent() as? ViewGroup
-        if (parent != null) {
-            parent.removeView(this)
-            super.destroy()
-        }
+        (getParent() as? ViewGroup)?.removeView(this)
+        super.destroy()
     }
 }

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -1,9 +1,3 @@
-v2.4.1
+v2.4.2
 
-* Add better support for mobile url conversions
-* Notification tab will keep first page in the same window; fixes marking notifications as read
-* Fix nav and status bar icon colors for custom themes (Android O+)
-* Fix biometric prompt, and prompt on activity resume
-* Fix notification title
-* Add option to open overlay links in browser
-* Disable swipe to refresh for composer and sharer pages
+* Fix back stack history

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -6,6 +6,11 @@
     <item text="" />
     -->
 
+    <version title="v2.4.2" />
+    <item text="Fix back stack history" />
+    <item text="" />
+    <item text="" />
+
     <version title="v2.4.1" />
     <item text="Add better support for mobile url conversions" />
     <item text="Notification tab will keep first page in the same window; fixes marking notifications as read" />
@@ -14,7 +19,6 @@
     <item text="Fix notification title" />
     <item text="Add option to open overlay links in browser" />
     <item text="Disable swipe to refresh for composer and sharer pages" />
-    <item text="" />
 
     <version title="v2.4.0" />
     <item text="Removed request services, which potentially caused phishing warnings." />

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.4.2
+* Fix back stack history
+
 ## v2.4.1
 * Add better support for mobile url conversions
 * Notification tab will keep first page in the same window; fixes marking notifications as read


### PR DESCRIPTION
Facebook is ridiculous and decides to randomly add its homepage to the back stack if it isn't already there. This results in the home page being scattered throughout the history, and sometimes twice in a row. We will filter this out and essentially filter out home stacks when there is more than one history item before the current page