### PR TITLE
Use MaterialDialog for webviews

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -282,6 +282,8 @@ dependencies {
     implementation kau.Dependencies.iconicsMaterial
     implementation kau.Dependencies.iconicsCommunity
 
+    implementation kau.Dependencies.materialDialog("input")
+
     implementation "org.jsoup:jsoup:${Versions.jsoup}"
 
     implementation "com.squareup.okhttp3:okhttp:${Versions.okhttp}"

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostChromeClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostChromeClients.kt
@@ -19,11 +19,16 @@ package com.pitchedapps.frost.web
 import android.net.Uri
 import android.webkit.ConsoleMessage
 import android.webkit.GeolocationPermissions
+import android.webkit.JsPromptResult
+import android.webkit.JsResult
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import ca.allanwang.kau.permissions.PERMISSION_ACCESS_FINE_LOCATION
 import ca.allanwang.kau.permissions.kauRequestPermissions
+import ca.allanwang.kau.utils.materialDialog
+import com.afollestad.materialdialogs.callbacks.onDismiss
+import com.afollestad.materialdialogs.input.input
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.contracts.ActivityContract
 import com.pitchedapps.frost.utils.L
@@ -71,6 +76,73 @@ class FrostChromeClient(web: FrostWebView) : WebChromeClient() {
         activity?.openFileChooser(filePathCallback, fileChooserParams)
             ?: webView.frostSnackbar(R.string.file_chooser_not_found)
         return activity != null
+    }
+
+    override fun onJsAlert(
+        view: WebView,
+        url: String,
+        message: String,
+        result: JsResult
+    ): Boolean {
+        view.context.materialDialog {
+            title(text = url)
+            message(text = message)
+            positiveButton { result.confirm() }
+            onDismiss { result.cancel() }
+        }
+        return true
+    }
+
+    override fun onJsConfirm(
+        view: WebView,
+        url: String,
+        message: String,
+        result: JsResult
+    ): Boolean {
+        view.context.materialDialog {
+            title(text = url)
+            message(text = message)
+            positiveButton { result.confirm() }
+            negativeButton { result.cancel() }
+            onDismiss { result.cancel() }
+        }
+        return true
+    }
+
+    override fun onJsBeforeUnload(
+        view: WebView,
+        url: String,
+        message: String,
+        result: JsResult
+    ): Boolean {
+        view.context.materialDialog {
+            title(text = url)
+            message(text = message)
+            positiveButton { result.confirm() }
+            negativeButton { result.cancel() }
+            onDismiss { result.cancel() }
+        }
+        return true
+    }
+
+    override fun onJsPrompt(
+        view: WebView,
+        url: String,
+        message: String,
+        defaultValue: String?,
+        result: JsPromptResult
+    ): Boolean {
+        view.context.materialDialog {
+            title(text = url)
+            message(text = message)
+            input(prefill = defaultValue) { _, charSequence ->
+                result.confirm(charSequence.toString())
+            }
+            // positive button added through input
+            negativeButton { result.cancel() }
+            onDismiss { result.cancel() }
+        }
+        return true
     }
 
     override fun onGeolocationPermissionsShowPrompt(

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -4,3 +4,5 @@ v2.4.2
 * Fix search suggestions
 * Redesign navigation layout
 * Update theme
+* Open formatted urls from context menu
+* Allow copying text with emojis

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <color name="frost_splash_background">@color/facebook_blue</color>
     <color name="facebook_blue">#3b5998</color>
+    <color name="facebook_blue_light">#6183C8</color>
     <color name="facebook_blue_dark">#2e4b86</color>
     <color name="frost_notification_accent">@color/facebook_blue</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,7 +3,7 @@
     <style name="FrostTheme" parent="Theme.MaterialComponents.NoActionBar">
         <item name="colorPrimary">@color/facebook_blue</item>
         <item name="colorPrimaryDark">@color/facebook_blue_dark</item>
-        <item name="colorAccent">@android:color/white</item>
+        <item name="colorAccent">@color/facebook_blue_light</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowBackground">@null</item>
         <item name="android:windowSoftInputMode">adjustResize</item>
@@ -14,7 +14,7 @@
     <style name="FrostTheme.Light" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="colorPrimary">@color/facebook_blue</item>
         <item name="colorPrimaryDark">@color/facebook_blue_dark</item>
-        <item name="colorAccent">@android:color/black</item>
+        <item name="colorAccent">@color/facebook_blue</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowBackground">@null</item>
         <item name="android:windowSoftInputMode">adjustResize</item>

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -11,6 +11,8 @@
     <item text="Fix search suggestions" />
     <item text="Redesign navigation layout" />
     <item text="Update theme" />
+    <item text="Open formatted urls from context menu" />
+    <item text="Allow copying text with emojis" />
     <item text="" />
 
     <version title="v2.4.1" />

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,8 @@
 * Fix search suggestions
 * Redesign navigation layout
 * Update theme
+* Open formatted urls from context menu
+* Allow copying text with emojis
 
 ## v2.4.1
 * Add better support for mobile url conversions


### PR DESCRIPTION
The default dialog has weird button backgrounds, which were also not visible due to Frost's accent colors. We will reroute js dialogs to MaterialDialog, and update the accent color so that the text is more visible