### PR TITLE
Remove autoplay settings

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/settings/Behaviour.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/settings/Behaviour.kt
@@ -19,9 +19,7 @@ package com.pitchedapps.frost.settings
 import ca.allanwang.kau.kpref.activity.KPrefAdapterBuilder
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.SettingsActivity
-import com.pitchedapps.frost.facebook.FB_URL_BASE
 import com.pitchedapps.frost.utils.Prefs
-import com.pitchedapps.frost.utils.launchWebOverlay
 
 /**
  * Created by Allan Wang on 2017-06-30.
@@ -72,12 +70,13 @@ fun SettingsActivity.getBehaviourPrefs(): KPrefAdapterBuilder.() -> Unit = {
         descRes = R.string.enable_pip_desc
     }
 
-    plainText(R.string.autoplay_settings) {
-        descRes = R.string.autoplay_settings_desc
-        onClick = {
-            launchWebOverlay("${FB_URL_BASE}settings/videos/")
-        }
-    }
+    // Not available for desktop user agent for now
+//    plainText(R.string.autoplay_settings) {
+//        descRes = R.string.autoplay_settings_desc
+//        onClick = {
+//            launchWebOverlay("${FB_URL_BASE}settings/videos/")
+//        }
+//    }
 
     checkbox(R.string.exit_confirmation, Prefs::exitConfirmation, { Prefs.exitConfirmation = it }) {
         descRes = R.string.exit_confirmation_desc


### PR DESCRIPTION
Resolves #1612 

Given that we've converted to desktop agents, autoplay is currently not an available setting. Will be reenabled if we switch back