### PR TITLE
Fixed blank loading of some weblinks

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
@@ -76,6 +76,7 @@ class FrostWebView @JvmOverloads constructor(
             mediaPlaybackRequiresUserGesture = false // TODO check if we need this
             allowFileAccess = true
             textZoom = Prefs.webTextScaling
+            domStorageEnabled = true
         }
         setLayerType(LAYER_TYPE_HARDWARE, null)
         // attempt to get custom client; otherwise fallback to original


### PR DESCRIPTION
Some links opened blank and needed the domStorage to be enabled to load