### PR TITLE
gradle: Remove F-Droid version name check

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,9 +44,6 @@ android {
         if (versionCode != androidGitVersion.code()) {
             throw new GradleException("Version code mismatch, expected ${androidGitVersion.code()}, got $versionCode")
         }
-        if (versionName != androidGitVersion.name()) {
-            throw new GradleException("Version name mismatch, expected ${androidGitVersion.name()}, got $versionName")
-        }
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         javaCompileOptions {


### PR DESCRIPTION
This breaks personal builds if git version does not match release
version.

* What went wrong:
A problem occurred evaluating project ':app'.
> Version name mismatch, expected 2.4.3-2-bdd3bee, got 2.4.3