### PR TITLE
Allow currentFragment to be nullable

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
@@ -810,7 +810,7 @@ abstract class BaseMainActivity : BaseActivity(), MainActivityContract,
     inline val currentFragment: BaseFragment?
         get() {
             val viewpager = contentBinding.viewpager
-            return supportFragmentManager.findFragmentByTag("android:switcher:${viewpager.id}:${viewpager.currentItem}") as? BaseFragment
+            return supportFragmentManager.findFragmentByTag("android:switcher:${viewpager.id}:${viewpager.currentItem}") as BaseFragment?
         }
 
     override fun reloadFragment(fragment: BaseFragment) {

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
@@ -791,7 +791,7 @@ abstract class BaseMainActivity : BaseActivity(), MainActivityContract,
                 return true
             }
         }
-        if (currentFragment.onBackPressed()) return true
+        if (currentFragment?.onBackPressed() == true) return true
         if (prefs.exitConfirmation) {
             materialDialog {
                 title(R.string.kau_exit)
@@ -807,10 +807,10 @@ abstract class BaseMainActivity : BaseActivity(), MainActivityContract,
         return false
     }
 
-    inline val currentFragment: BaseFragment
+    inline val currentFragment: BaseFragment?
         get() {
             val viewpager = contentBinding.viewpager
-            return supportFragmentManager.findFragmentByTag("android:switcher:${viewpager.id}:${viewpager.currentItem}") as BaseFragment
+            return supportFragmentManager.findFragmentByTag("android:switcher:${viewpager.id}:${viewpager.currentItem}") as? BaseFragment
         }
 
     override fun reloadFragment(fragment: BaseFragment) {

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/MainActivity.kt
@@ -82,7 +82,7 @@ class MainActivity : BaseMainActivity() {
         tabs.addOnTabSelectedListener(object : TabLayout.ViewPagerOnTabSelectedListener(viewpager) {
             override fun onTabReselected(tab: TabLayout.Tab) {
                 super.onTabReselected(tab)
-                currentFragment.onTabClick()
+                currentFragment?.onTabClick()
             }
 
             override fun onTabSelected(tab: TabLayout.Tab) {


### PR DESCRIPTION
Resolves #1642

While the viewpager is expected to always contain a fragment, the logic around it still holds if it is nullable. Presumably this may be due to some quick inputs before everything has loaded