### PR TITLE
Prefs

### DIFF
--- a/app/src/androidTest/kotlin/com/pitchedapps/frost/FrostTestApp.kt
+++ b/app/src/androidTest/kotlin/com/pitchedapps/frost/FrostTestApp.kt
@@ -23,7 +23,7 @@ import ca.allanwang.kau.kpref.KPrefFactory
 import ca.allanwang.kau.kpref.KPrefFactoryInMemory
 import com.pitchedapps.frost.db.FrostDatabase
 import com.pitchedapps.frost.facebook.FbCookie
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.Showcase
 import org.junit.rules.TestRule
 import org.junit.runner.Description

--- a/app/src/androidTest/kotlin/com/pitchedapps/frost/FrostTestApp.kt
+++ b/app/src/androidTest/kotlin/com/pitchedapps/frost/FrostTestApp.kt
@@ -24,7 +24,6 @@ import ca.allanwang.kau.kpref.KPrefFactoryInMemory
 import com.pitchedapps.frost.db.FrostDatabase
 import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.prefs.Prefs
-import com.pitchedapps.frost.utils.Showcase
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -53,7 +52,6 @@ class FrostTestRule : TestRule {
 
                 // Reset prefs
                 get<Prefs>().reset()
-                get<Showcase>().reset()
 
                 base.evaluate()
             }
@@ -72,7 +70,6 @@ class FrostTestApp : Application() {
                     FrostDatabase.module(),
                     prefFactoryModule(),
                     Prefs.module(),
-                    Showcase.module(),
                     FbCookie.module()
                 )
             )

--- a/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
@@ -34,6 +34,7 @@ import com.pitchedapps.frost.services.setupNotificationChannels
 import com.pitchedapps.frost.utils.BuildUtils
 import com.pitchedapps.frost.utils.FrostPglAdBlock
 import com.pitchedapps.frost.utils.L
+import java.util.Random
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.KoinComponent
@@ -41,7 +42,6 @@ import org.koin.core.context.startKoin
 import org.koin.core.get
 import org.koin.core.module.Module
 import org.koin.dsl.module
-import java.util.Random
 
 /**
  * Created by Allan Wang on 2017-05-28.

--- a/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
@@ -34,8 +34,6 @@ import com.pitchedapps.frost.services.setupNotificationChannels
 import com.pitchedapps.frost.utils.BuildUtils
 import com.pitchedapps.frost.utils.FrostPglAdBlock
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Showcase
-import java.util.Random
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.KoinComponent
@@ -43,13 +41,13 @@ import org.koin.core.context.startKoin
 import org.koin.core.get
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import java.util.Random
 
 /**
  * Created by Allan Wang on 2017-05-28.
  */
 class FrostApp : Application(), KoinComponent {
 
-    private lateinit var showcasePrefs: Showcase
     private lateinit var prefs: Prefs
 
     override fun onCreate() {
@@ -63,7 +61,6 @@ class FrostApp : Application(), KoinComponent {
                     FrostDatabase.module(),
                     prefFactoryModule(),
                     Prefs.module(),
-                    Showcase.module(),
                     FbCookie.module()
                 )
             )
@@ -73,7 +70,6 @@ class FrostApp : Application(), KoinComponent {
             return
         }
         prefs = get()
-        showcasePrefs = get()
         initPrefs()
 //        initBugsnag()
 
@@ -108,8 +104,7 @@ class FrostApp : Application(), KoinComponent {
     }
 
     private fun initPrefs() {
-        prefs.deleteKeys("search_bar")
-        showcasePrefs.deleteKeys("shown_release", "experimental_by_default")
+        prefs.deleteKeys("search_bar", "shown_release", "experimental_by_default")
         KL.shouldLog = { BuildConfig.DEBUG }
         L.shouldLog = {
             when (it) {

--- a/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
@@ -28,12 +28,12 @@ import com.bugsnag.android.Bugsnag
 import com.bugsnag.android.Configuration
 import com.pitchedapps.frost.db.FrostDatabase
 import com.pitchedapps.frost.facebook.FbCookie
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.services.scheduleNotificationsFromPrefs
 import com.pitchedapps.frost.services.setupNotificationChannels
 import com.pitchedapps.frost.utils.BuildUtils
 import com.pitchedapps.frost.utils.FrostPglAdBlock
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.Showcase
 import java.util.Random
 import org.koin.android.ext.koin.androidContext

--- a/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/FrostApp.kt
@@ -33,7 +33,7 @@ import com.pitchedapps.frost.services.setupNotificationChannels
 import com.pitchedapps.frost.utils.BuildUtils
 import com.pitchedapps.frost.utils.FrostPglAdBlock
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.Showcase
 import java.util.Random
 import org.koin.android.ext.koin.androidContext

--- a/app/src/main/kotlin/com/pitchedapps/frost/StartActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/StartActivity.kt
@@ -37,10 +37,10 @@ import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.db.GenericDao
 import com.pitchedapps.frost.db.selectAll
 import com.pitchedapps.frost.facebook.FbCookie
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.BiometricUtils
 import com.pitchedapps.frost.utils.EXTRA_COOKIES
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.launchNewTask
 import com.pitchedapps.frost.utils.loadAssets
 import java.util.ArrayList

--- a/app/src/main/kotlin/com/pitchedapps/frost/StartActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/StartActivity.kt
@@ -40,7 +40,7 @@ import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.utils.BiometricUtils
 import com.pitchedapps.frost.utils.EXTRA_COOKIES
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.launchNewTask
 import com.pitchedapps.frost.utils.loadAssets
 import java.util.ArrayList

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/AboutActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/AboutActivity.kt
@@ -47,8 +47,8 @@ import com.mikepenz.iconics.typeface.library.community.material.CommunityMateria
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.R
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import org.koin.android.ext.android.inject
 
 /**
@@ -108,13 +108,15 @@ class AboutActivity : AboutActivityBase(null) {
             isOpenSource = true,
             libraryDescription = string(R.string.frost_description),
             libraryVersion = BuildConfig.VERSION_NAME,
-            licenses = setOf(License(
-                definedName = "gplv3",
-                licenseName = "GNU GPL v3",
-                licenseWebsite = "https://www.gnu.org/licenses/gpl-3.0.en.html",
-                licenseDescription = "",
-                licenseShortDescription = ""
-            ))
+            licenses = setOf(
+                License(
+                    definedName = "gplv3",
+                    licenseName = "GNU GPL v3",
+                    licenseWebsite = "https://www.gnu.org/licenses/gpl-3.0.en.html",
+                    licenseDescription = "",
+                    licenseShortDescription = ""
+                )
+            )
         )
         adapter.add(LibraryIItem(frost)).add(AboutLinks())
         adapter.onClickListener = { _, _, item, _ ->

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/AboutActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/AboutActivity.kt
@@ -48,7 +48,7 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.android.ext.android.inject
 
 /**

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseActivity.kt
@@ -22,7 +22,7 @@ import ca.allanwang.kau.internal.KauBaseActivity
 import ca.allanwang.kau.searchview.SearchViewHolder
 import com.pitchedapps.frost.contracts.VideoViewHolder
 import com.pitchedapps.frost.facebook.FbCookie
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.setFrostTheme
 import org.koin.android.ext.android.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/DebugActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/DebugActivity.kt
@@ -30,8 +30,8 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.databinding.ActivityDebugBinding
 import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.injectors.JsActions
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.createFreshDir
 import com.pitchedapps.frost.utils.setFrostColors
 import java.io.File

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/DebugActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/DebugActivity.kt
@@ -31,7 +31,7 @@ import com.pitchedapps.frost.databinding.ActivityDebugBinding
 import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.injectors.JsActions
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.createFreshDir
 import com.pitchedapps.frost.utils.setFrostColors
 import java.io.File

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/ImageActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/ImageActivity.kt
@@ -55,11 +55,11 @@ import com.pitchedapps.frost.facebook.get
 import com.pitchedapps.frost.facebook.requests.call
 import com.pitchedapps.frost.facebook.requests.getFullSizedImageUrl
 import com.pitchedapps.frost.facebook.requests.requestBuilder
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.services.LocalService
 import com.pitchedapps.frost.utils.ARG_COOKIE
 import com.pitchedapps.frost.utils.ARG_IMAGE_URL
 import com.pitchedapps.frost.utils.ARG_TEXT
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.frostDownload
 import com.pitchedapps.frost.utils.frostSnackbar
 import com.pitchedapps.frost.utils.frostUriFromFile

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/ImageActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/ImageActivity.kt
@@ -59,7 +59,7 @@ import com.pitchedapps.frost.services.LocalService
 import com.pitchedapps.frost.utils.ARG_COOKIE
 import com.pitchedapps.frost.utils.ARG_IMAGE_URL
 import com.pitchedapps.frost.utils.ARG_TEXT
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.frostDownload
 import com.pitchedapps.frost.utils.frostSnackbar
 import com.pitchedapps.frost.utils.frostUriFromFile

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/IntroActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/IntroActivity.kt
@@ -28,6 +28,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.viewpager.widget.ViewPager
 import ca.allanwang.kau.internal.KauBaseActivity
+import ca.allanwang.kau.utils.blendWith
 import ca.allanwang.kau.utils.color
 import ca.allanwang.kau.utils.fadeScaleTransition
 import ca.allanwang.kau.utils.navigationBarColor

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/IntroActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/IntroActivity.kt
@@ -47,7 +47,7 @@ import com.pitchedapps.frost.intro.IntroFragmentTheme
 import com.pitchedapps.frost.intro.IntroFragmentWelcome
 import com.pitchedapps.frost.intro.IntroTabContextFragment
 import com.pitchedapps.frost.intro.IntroTabTouchFragment
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.cookies
 import com.pitchedapps.frost.utils.launchNewTask
 import com.pitchedapps.frost.utils.loadAssets

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/IntroActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/IntroActivity.kt
@@ -28,7 +28,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
 import androidx.viewpager.widget.ViewPager
 import ca.allanwang.kau.internal.KauBaseActivity
-import ca.allanwang.kau.utils.blendWith
 import ca.allanwang.kau.utils.color
 import ca.allanwang.kau.utils.fadeScaleTransition
 import ca.allanwang.kau.utils.navigationBarColor

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/LoginActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/LoginActivity.kt
@@ -41,7 +41,6 @@ import com.pitchedapps.frost.facebook.profilePictureUrl
 import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Showcase
 import com.pitchedapps.frost.utils.frostEvent
 import com.pitchedapps.frost.utils.frostJsoup
 import com.pitchedapps.frost.utils.launchNewTask
@@ -49,8 +48,6 @@ import com.pitchedapps.frost.utils.logFrostEvent
 import com.pitchedapps.frost.utils.setFrostColors
 import com.pitchedapps.frost.utils.uniqueOnly
 import com.pitchedapps.frost.web.LoginWebView
-import java.net.UnknownHostException
-import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -60,6 +57,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.koin.android.ext.android.inject
+import java.net.UnknownHostException
+import kotlin.coroutines.resume
 
 /**
  * Created by Allan Wang on 2017-06-01.
@@ -72,7 +71,6 @@ class LoginActivity : BaseActivity() {
     private val textview: AppCompatTextView by bindView(R.id.textview)
     private val profile: ImageView by bindView(R.id.profile)
     private val cookieDao: CookieDao by inject()
-    private val showcasePrefs: Showcase by inject()
 
     private lateinit var profileLoader: RequestManager
     private val refreshChannel = Channel<Boolean>(10)
@@ -138,7 +136,7 @@ class LoginActivity : BaseActivity() {
          */
         val cookies = ArrayList(cookieDao.selectAll())
         delay(1000)
-        if (showcasePrefs.intro)
+        if (prefs.intro)
             launchNewTask<IntroActivity>(cookies, true)
         else
             launchNewTask<MainActivity>(cookies, true)

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/LoginActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/LoginActivity.kt
@@ -48,6 +48,8 @@ import com.pitchedapps.frost.utils.logFrostEvent
 import com.pitchedapps.frost.utils.setFrostColors
 import com.pitchedapps.frost.utils.uniqueOnly
 import com.pitchedapps.frost.web.LoginWebView
+import java.net.UnknownHostException
+import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
@@ -57,8 +59,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.koin.android.ext.android.inject
-import java.net.UnknownHostException
-import kotlin.coroutines.resume
 
 /**
  * Created by Allan Wang on 2017-06-01.

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/SettingsActivity.kt
@@ -52,7 +52,7 @@ import com.pitchedapps.frost.settings.getNotificationPrefs
 import com.pitchedapps.frost.settings.getSecurityPrefs
 import com.pitchedapps.frost.settings.sendDebug
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.REQUEST_REFRESH
 import com.pitchedapps.frost.utils.REQUEST_RESTART
 import com.pitchedapps.frost.utils.cookies

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/SettingsActivity.kt
@@ -43,6 +43,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.db.NotificationDao
 import com.pitchedapps.frost.enums.Support
 import com.pitchedapps.frost.facebook.FbCookie
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.settings.getAppearancePrefs
 import com.pitchedapps.frost.settings.getBehaviourPrefs
 import com.pitchedapps.frost.settings.getDebugPrefs
@@ -52,7 +53,6 @@ import com.pitchedapps.frost.settings.getNotificationPrefs
 import com.pitchedapps.frost.settings.getSecurityPrefs
 import com.pitchedapps.frost.settings.sendDebug
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.REQUEST_REFRESH
 import com.pitchedapps.frost.utils.REQUEST_RESTART
 import com.pitchedapps.frost.utils.cookies

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/WebOverlayActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/WebOverlayActivity.kt
@@ -66,7 +66,6 @@ import com.pitchedapps.frost.utils.ARG_URL
 import com.pitchedapps.frost.utils.ARG_USER_ID
 import com.pitchedapps.frost.utils.BiometricUtils
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Showcase
 import com.pitchedapps.frost.utils.frostSnackbar
 import com.pitchedapps.frost.utils.setFrostColors
 import com.pitchedapps.frost.views.FrostContentWeb
@@ -76,7 +75,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import org.koin.android.ext.android.inject
 
 /**
  * Created by Allan Wang on 2017-06-01.
@@ -169,8 +167,6 @@ abstract class WebOverlayActivityBase(private val userAgent: String = USER_AGENT
         get() = content.coreView
     private val coordinator: CoordinatorLayout by bindView(R.id.overlay_main_content)
 
-    private val showcasePrefs: Showcase by inject()
-
     private inline val urlTest: String?
         get() = intent.getStringExtra(ARG_URL) ?: intent.dataString
 
@@ -231,7 +227,7 @@ abstract class WebOverlayActivityBase(private val userAgent: String = USER_AGENT
                 }
                 authDefer.await()
                 reloadBase(true)
-                if (showcasePrefs.firstWebOverlay) {
+                if (prefs.firstWebOverlay) {
                     coordinator.frostSnackbar(R.string.web_overlay_swipe_hint) {
                         duration = BaseTransientBottomBar.LENGTH_INDEFINITE
                         setAction(R.string.kau_got_it) { dismiss() }

--- a/app/src/main/kotlin/com/pitchedapps/frost/contracts/ActivityContract.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/contracts/ActivityContract.kt
@@ -33,6 +33,7 @@ interface MainActivityContract : ActivityContract, MainFabContract {
     val headerBadgeChannel: BroadcastChannel<String>
     fun setTitle(res: Int)
     fun setTitle(text: CharSequence)
+
     /**
      * Available on all threads
      */

--- a/app/src/main/kotlin/com/pitchedapps/frost/db/CookiesDb.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/db/CookiesDb.kt
@@ -23,7 +23,7 @@ import androidx.room.Entity
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import kotlinx.android.parcel.Parcelize
 
 /**

--- a/app/src/main/kotlin/com/pitchedapps/frost/enums/MainActivityLayout.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/enums/MainActivityLayout.kt
@@ -17,7 +17,7 @@
 package com.pitchedapps.frost.enums
 
 import com.pitchedapps.frost.R
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 
 /**
  * Created by Allan Wang on 2017-08-19.

--- a/app/src/main/kotlin/com/pitchedapps/frost/enums/Theme.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/enums/Theme.kt
@@ -22,7 +22,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.injectors.CssAssets
 import com.pitchedapps.frost.injectors.InjectorContract
 import com.pitchedapps.frost.injectors.JsActions
-import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.prefs.sections.ThemePrefs
 
 /**
  * Created by Allan Wang on 2017-06-14.
@@ -33,11 +33,11 @@ const val BLUE_LIGHT = 0xff5d86dd.toInt()
 enum class Theme(
     @StringRes val textRes: Int,
     val injector: InjectorContract,
-    val textColorGetter: (Prefs) -> Int,
-    val accentColorGetter: (Prefs) -> Int,
-    val backgroundColorGetter: (Prefs) -> Int,
-    val headerColorGetter: (Prefs) -> Int,
-    val iconColorGetter: (Prefs) -> Int
+    val textColorGetter: (ThemePrefs) -> Int,
+    val accentColorGetter: (ThemePrefs) -> Int,
+    val backgroundColorGetter: (ThemePrefs) -> Int,
+    val headerColorGetter: (ThemePrefs) -> Int,
+    val iconColorGetter: (ThemePrefs) -> Int
 ) {
 
     DEFAULT(R.string.kau_default,

--- a/app/src/main/kotlin/com/pitchedapps/frost/enums/Theme.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/enums/Theme.kt
@@ -22,7 +22,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.injectors.CssAssets
 import com.pitchedapps.frost.injectors.InjectorContract
 import com.pitchedapps.frost.injectors.JsActions
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 
 /**
  * Created by Allan Wang on 2017-06-14.

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbConst.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbConst.kt
@@ -41,6 +41,7 @@ const val FB_HOME_URL = "${FB_URL_BASE}home.php"
 // Default user agent
 const val USER_AGENT_MOBILE_CONST =
     "Mozilla/5.0 (Linux; Android 8.0.0; ONEPLUS A3000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36"
+
 // Desktop agent, for pages like messages
 const val USER_AGENT_DESKTOP_CONST =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36"
@@ -52,6 +53,7 @@ const val USER_AGENT = USER_AGENT_DESKTOP_CONST
  * have properly set in
  */
 const val WEB_LOAD_DELAY = 50L
+
 /**
  * Additional delay for transition when called from commit.
  * Note that transitions are also called from onFinish, so this value

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbCookie.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbCookie.kt
@@ -24,8 +24,8 @@ import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.db.deleteById
 import com.pitchedapps.frost.db.save
 import com.pitchedapps.frost.db.selectById
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.cookies
 import com.pitchedapps.frost.utils.launchLogin
 import kotlin.coroutines.resume

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbCookie.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbCookie.kt
@@ -25,7 +25,7 @@ import com.pitchedapps.frost.db.deleteById
 import com.pitchedapps.frost.db.save
 import com.pitchedapps.frost.db.selectById
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.cookies
 import com.pitchedapps.frost.utils.launchLogin
 import kotlin.coroutines.resume

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
@@ -55,6 +55,7 @@ enum class FbItem(
     PHOTOS(R.string.photos, GoogleMaterial.Icon.gmd_photo, "me/photos"),
     PROFILE(R.string.profile, CommunityMaterial.Icon.cmd_account, "me"),
     SAVED(R.string.saved, GoogleMaterial.Icon.gmd_bookmark, "saved"),
+
     /**
      * Note that this url only works if a query (?q=) is provided
      */
@@ -63,6 +64,7 @@ enum class FbItem(
         GoogleMaterial.Icon.gmd_search,
         "search/top"
     ),
+
     /**
      * Non mbasic search cannot be parsed.
      */

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbUrlFormatter.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbUrlFormatter.kt
@@ -114,6 +114,7 @@ class FbUrlFormatter(url: String) {
     companion object {
 
         const val VIDEO_REDIRECT = "/video_redirect/?src="
+
         /**
          * Items here are explicitly removed from the url
          * Taken from FaceSlim

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/parsers/SearchParser.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/parsers/SearchParser.kt
@@ -32,7 +32,8 @@ import org.jsoup.nodes.Element
  */
 object SearchParser : FrostParser<FrostSearches> by SearchParserImpl() {
     fun query(cookie: String?, input: String): ParseResponse<FrostSearches>? {
-        val url = "${FbItem._SEARCH_PARSE.url}/?q=${if (input.isNotBlank()) input.urlEncode() else "a"}"
+        val url =
+            "${FbItem._SEARCH_PARSE.url}/?q=${if (input.isNotBlank()) input.urlEncode() else "a"}"
         L._i { "Search Query $url" }
         return parseFromUrl(cookie, url)
     }

--- a/app/src/main/kotlin/com/pitchedapps/frost/fragments/FragmentBase.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/fragments/FragmentBase.kt
@@ -34,9 +34,9 @@ import com.pitchedapps.frost.contracts.MainFabContract
 import com.pitchedapps.frost.enums.FeedSort
 import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.facebook.FbItem
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.ARG_URL
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.REQUEST_REFRESH
 import com.pitchedapps.frost.utils.REQUEST_TEXT_ZOOM
 import com.pitchedapps.frost.utils.frostEvent

--- a/app/src/main/kotlin/com/pitchedapps/frost/fragments/FragmentBase.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/fragments/FragmentBase.kt
@@ -36,7 +36,7 @@ import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.utils.ARG_URL
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.REQUEST_REFRESH
 import com.pitchedapps.frost.utils.REQUEST_TEXT_ZOOM
 import com.pitchedapps.frost.utils.frostEvent

--- a/app/src/main/kotlin/com/pitchedapps/frost/iitems/GenericIItems.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/iitems/GenericIItems.kt
@@ -28,7 +28,7 @@ import com.mikepenz.fastadapter.IAdapter
 import com.mikepenz.fastadapter.select.selectExtension
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.facebook.FbCookie
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.launchWebOverlay
 import org.koin.core.KoinComponent
 import org.koin.core.inject

--- a/app/src/main/kotlin/com/pitchedapps/frost/iitems/NotificationIItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/iitems/NotificationIItem.kt
@@ -25,6 +25,7 @@ import ca.allanwang.kau.ui.createSimpleRippleDrawable
 import ca.allanwang.kau.utils.bindView
 import ca.allanwang.kau.utils.gone
 import ca.allanwang.kau.utils.visible
+import ca.allanwang.kau.utils.withAlpha
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import com.mikepenz.fastadapter.diff.DiffCallback

--- a/app/src/main/kotlin/com/pitchedapps/frost/iitems/NotificationIItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/iitems/NotificationIItem.kt
@@ -36,7 +36,7 @@ import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.parsers.FrostNotif
 import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.isIndependent
 import com.pitchedapps.frost.utils.launchWebOverlay
 import org.koin.core.KoinComponent

--- a/app/src/main/kotlin/com/pitchedapps/frost/iitems/NotificationIItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/iitems/NotificationIItem.kt
@@ -25,7 +25,6 @@ import ca.allanwang.kau.ui.createSimpleRippleDrawable
 import ca.allanwang.kau.utils.bindView
 import ca.allanwang.kau.utils.gone
 import ca.allanwang.kau.utils.visible
-import ca.allanwang.kau.utils.withAlpha
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import com.mikepenz.fastadapter.diff.DiffCallback

--- a/app/src/main/kotlin/com/pitchedapps/frost/iitems/TabIItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/iitems/TabIItem.kt
@@ -29,7 +29,7 @@ import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.drag.IDraggable
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.facebook.FbItem
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAssets.kt
@@ -27,7 +27,7 @@ import ca.allanwang.kau.utils.toRgbaString
 import ca.allanwang.kau.utils.use
 import ca.allanwang.kau.utils.withAlpha
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.util.Locale

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAssets.kt
@@ -26,8 +26,8 @@ import ca.allanwang.kau.utils.colorToForeground
 import ca.allanwang.kau.utils.toRgbaString
 import ca.allanwang.kau.utils.use
 import ca.allanwang.kau.utils.withAlpha
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.util.Locale

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAssets.kt
@@ -102,8 +102,8 @@ enum class CssAssets(val folder: String = THEME_FOLDER) : InjectorContract {
         // Ensures that all non themes and the selected theme are loaded
         suspend fun load(context: Context, prefs: Prefs) {
             withContext(Dispatchers.IO) {
-                val currentTheme = prefs.t.injector as? CssAssets
-                val (themes, others) = CssAssets.values().partition { it.folder == THEME_FOLDER }
+                val currentTheme = prefs.themeInjector as? CssAssets
+                val (themes, others) = values().partition { it.folder == THEME_FOLDER }
                 themes.filter { it != currentTheme }.forEach { it.reset() }
                 currentTheme?.injector(context, prefs)
                 others.forEach { it.injector(context, prefs) }

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssHider.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssHider.kt
@@ -17,7 +17,7 @@
 package com.pitchedapps.frost.injectors
 
 import android.webkit.WebView
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 
 /**
  * Created by Allan Wang on 2017-05-31.

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssSmallAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssSmallAssets.kt
@@ -17,7 +17,7 @@
 package com.pitchedapps.frost.injectors
 
 import android.webkit.WebView
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 
 /**
  * Small misc inline css assets

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsActions.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsActions.kt
@@ -18,7 +18,7 @@ package com.pitchedapps.frost.injectors
 
 import android.webkit.WebView
 import com.pitchedapps.frost.facebook.FB_URL_BASE
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 
 /**
  * Created by Allan Wang on 2017-05-31.

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
@@ -20,8 +20,8 @@ import android.content.Context
 import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import ca.allanwang.kau.kotlin.lazyContext
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.util.Locale

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
@@ -21,7 +21,7 @@ import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import ca.allanwang.kau.kotlin.lazyContext
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import java.io.BufferedReader
 import java.io.FileNotFoundException
 import java.util.Locale

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
@@ -19,7 +19,7 @@ package com.pitchedapps.frost.injectors
 import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.web.FrostWebViewClient
 import kotlin.random.Random
 import org.apache.commons.text.StringEscapeUtils

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
@@ -18,8 +18,8 @@ package com.pitchedapps.frost.injectors
 
 import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.web.FrostWebViewClient
 import kotlin.random.Random
 import org.apache.commons.text.StringEscapeUtils
@@ -85,6 +85,7 @@ class JsBuilder {
  */
 interface InjectorContract {
     fun inject(webView: WebView, prefs: Prefs)
+
     /**
      * Toggle the injector (usually through Prefs
      * If false, will fallback to an empty action

--- a/app/src/main/kotlin/com/pitchedapps/frost/intro/IntroMainFragments.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/intro/IntroMainFragments.kt
@@ -36,7 +36,7 @@ import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.IntroActivity
 import com.pitchedapps.frost.databinding.IntroAnalyticsBinding
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import kotlin.math.abs
 import org.koin.android.ext.android.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/kotlin/Flyweight.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/kotlin/Flyweight.kt
@@ -45,15 +45,19 @@ class Flyweight<K, V>(
 
     // Receives a key and a pending request
     private val actionChannel = Channel<Pair<K, CompletableDeferred<V>>>(Channel.UNLIMITED)
+
     // Receives a key to invalidate the associated value
     private val invalidatorChannel = Channel<K>(Channel.UNLIMITED)
+
     // Receives a key and the resulting value
     private val receiverChannel = Channel<Pair<K, Result<V>>>(Channel.UNLIMITED)
 
     // Keeps track of keys and associated update times
     private val conditionMap: MutableMap<K, Long> = mutableMapOf()
+
     // Keeps track of keys and associated values
     private val resultMap: MutableMap<K, Result<V>> = mutableMapOf()
+
     // Keeps track of unfulfilled actions
     // Note that the explicit type is very important here. See https://youtrack.jetbrains.net/issue/KT-18053
     private val pendingMap: MutableMap<K, MutableList<CompletableDeferred<V>>> = ConcurrentHashMap()

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/OldPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/OldPrefs.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 Allan Wang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.pitchedapps.frost.prefs
+
+import ca.allanwang.kau.kpref.KPref
+import ca.allanwang.kau.kpref.KPrefFactory
+import com.pitchedapps.frost.BuildConfig
+import com.pitchedapps.frost.enums.FeedSort
+
+/**
+ * Created by Allan Wang on 2017-05-28.
+ *
+ * Shared Preference object with lazy cached retrievals
+ *
+ * As of 2020-07-18, prefs have been split up into multiple folders
+ */
+@Deprecated(level = DeprecationLevel.WARNING, message = "Use pref segments")
+class OldPrefs(factory: KPrefFactory) : KPref("${BuildConfig.APPLICATION_ID}.prefs", factory) {
+
+    var lastLaunch: Long by kpref("last_launch", -1L)
+
+    var userId: Long by kpref("user_id", -1L)
+
+    var prevId: Long by kpref("prev_id", -1L)
+
+    var theme: Int by kpref("theme", 0)
+
+    var customTextColor: Int by kpref("color_text", 0xffeceff1.toInt())
+
+    var customAccentColor: Int by kpref("color_accent", 0xff0288d1.toInt())
+
+    var customBackgroundColor: Int by kpref("color_bg", 0xff212121.toInt())
+
+    var customHeaderColor: Int by kpref("color_header", 0xff01579b.toInt())
+
+    var customIconColor: Int by kpref("color_icons", 0xffeceff1.toInt())
+
+    var exitConfirmation: Boolean by kpref("exit_confirmation", true)
+
+    var notificationFreq: Long by kpref("notification_freq", 15L)
+
+    var versionCode: Int by kpref("version_code", -1)
+
+    var prevVersionCode: Int by kpref("prev_version_code", -1)
+
+    var installDate: Long by kpref("install_date", -1L)
+
+    var identifier: Int by kpref("identifier", -1)
+
+    var tintNavBar: Boolean by kpref("tint_nav_bar", true)
+
+    var webTextScaling: Int by kpref("web_text_scaling", 100)
+
+    var feedSort: Int by kpref("feed_sort", FeedSort.DEFAULT.ordinal)
+
+    var aggressiveRecents: Boolean by kpref("aggressive_recents", false)
+
+    var showComposer: Boolean by kpref("status_composer_feed", true)
+
+    var showSuggestedFriends: Boolean by kpref("suggested_friends_feed", true)
+
+    var showSuggestedGroups: Boolean by kpref("suggested_groups_feed", true)
+
+    var showFacebookAds: Boolean by kpref("facebook_ads", false)
+
+    var showStories: Boolean by kpref("show_stories", true)
+
+    var animate: Boolean by kpref("fancy_animations", true)
+
+    var notificationKeywords: Set<String> by kpref("notification_keywords", mutableSetOf())
+
+    var notificationsGeneral: Boolean by kpref("notification_general", true)
+
+    var notificationAllAccounts: Boolean by kpref("notification_all_accounts", true)
+
+    var notificationsInstantMessages: Boolean by kpref("notification_im", true)
+
+    var notificationsImAllAccounts: Boolean by kpref("notification_im_all_accounts", false)
+
+    var notificationVibrate: Boolean by kpref("notification_vibrate", true)
+
+    var notificationSound: Boolean by kpref("notification_sound", true)
+
+    var notificationRingtone: String by kpref("notification_ringtone", "")
+
+    var messageRingtone: String by kpref("message_ringtone", "")
+
+    var notificationLights: Boolean by kpref("notification_lights", true)
+
+    var messageScrollToBottom: Boolean by kpref("message_scroll_to_bottom", false)
+
+    var enablePip: Boolean by kpref("enable_pip", true)
+
+    /**
+     * Despite the naming, this toggle currently only enables debug logging.
+     * Verbose is never logged in release builds.
+     */
+    var verboseLogging: Boolean by kpref("verbose_logging", false)
+
+    var analytics: Boolean by kpref("analytics", false) {
+//        if (!BuildConfig.DEBUG) {
+//            if (it) {
+//                Bugsnag.setAutoCaptureSessions(true)
+//                Bugsnag.enableExceptionHandler()
+//            } else {
+//                Bugsnag.setAutoCaptureSessions(false)
+//                Bugsnag.disableExceptionHandler()
+//            }
+//        }
+    }
+
+    var biometricsEnabled: Boolean by kpref("biometrics_enabled", false)
+
+    var overlayEnabled: Boolean by kpref("overlay_enabled", true)
+
+    var overlayFullScreenSwipe: Boolean by kpref("overlay_full_screen_swipe", true)
+
+    var viewpagerSwipe: Boolean by kpref("viewpager_swipe", true)
+
+    var loadMediaOnMeteredNetwork: Boolean by kpref("media_on_metered_network", true)
+
+    var debugSettings: Boolean by kpref("debug_settings", false)
+
+    var linksInDefaultApp: Boolean by kpref("link_in_default_app", false)
+
+    var mainActivityLayoutType: Int by kpref("main_activity_layout_type", 0)
+
+    var blackMediaBg: Boolean by kpref("black_media_bg", false)
+
+    var autoRefreshFeed: Boolean by kpref("auto_refresh_feed", false)
+
+    var showCreateFab: Boolean by kpref("show_create_fab", true)
+
+    var fullSizeImage: Boolean by kpref("full_size_image", false)
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/Prefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/Prefs.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Allan Wang
+ * Copyright 2020 Allan Wang
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,197 +16,53 @@
  */
 package com.pitchedapps.frost.prefs
 
-import android.graphics.Color
-import ca.allanwang.kau.kotlin.lazyResettable
-import ca.allanwang.kau.kpref.KPref
-import ca.allanwang.kau.kpref.KPrefFactory
-import ca.allanwang.kau.utils.colorToForeground
-import ca.allanwang.kau.utils.isColorVisibleOn
-import ca.allanwang.kau.utils.withAlpha
-import com.pitchedapps.frost.BuildConfig
-import com.pitchedapps.frost.enums.FACEBOOK_BLUE
-import com.pitchedapps.frost.enums.FeedSort
-import com.pitchedapps.frost.enums.MainActivityLayout
-import com.pitchedapps.frost.enums.Theme
-import com.pitchedapps.frost.injectors.InjectorContract
+import com.pitchedapps.frost.prefs.sections.BehaviourPrefs
+import com.pitchedapps.frost.prefs.sections.BehaviourPrefsImpl
+import com.pitchedapps.frost.prefs.sections.CorePrefs
+import com.pitchedapps.frost.prefs.sections.CorePrefsImpl
+import com.pitchedapps.frost.prefs.sections.FeedPrefs
+import com.pitchedapps.frost.prefs.sections.FeedPrefsImpl
+import com.pitchedapps.frost.prefs.sections.NotifPrefs
+import com.pitchedapps.frost.prefs.sections.NotifPrefsImpl
+import com.pitchedapps.frost.prefs.sections.ThemePrefs
+import com.pitchedapps.frost.prefs.sections.ThemePrefsImpl
 import org.koin.core.context.KoinContextHandler
 import org.koin.dsl.module
 
-/**
- * Created by Allan Wang on 2017-05-28.
- *
- * Shared Preference object with lazy cached retrievals
- */
-class Prefs(factory: KPrefFactory) : KPref("${BuildConfig.APPLICATION_ID}.prefs", factory) {
-
-    var lastLaunch: Long by kpref("last_launch", -1L)
-
-    var userId: Long by kpref("user_id", -1L)
-
-    var prevId: Long by kpref("prev_id", -1L)
-
-    var theme: Int by kpref("theme", 0) { _: Int ->
-        loader.invalidate()
-    }
-
-    var customTextColor: Int by kpref("color_text", 0xffeceff1.toInt())
-
-    var customAccentColor: Int by kpref("color_accent", 0xff0288d1.toInt())
-
-    var customBackgroundColor: Int by kpref("color_bg", 0xff212121.toInt())
-
-    var customHeaderColor: Int by kpref("color_header", 0xff01579b.toInt())
-
-    var customIconColor: Int by kpref("color_icons", 0xffeceff1.toInt())
-
-    var exitConfirmation: Boolean by kpref("exit_confirmation", true)
-
-    var notificationFreq: Long by kpref("notification_freq", 15L)
-
-    var versionCode: Int by kpref("version_code", -1)
-
-    var prevVersionCode: Int by kpref("prev_version_code", -1)
-
-    var installDate: Long by kpref("install_date", -1L)
-
-    var identifier: Int by kpref("identifier", -1)
-
-    private val loader = lazyResettable { Theme.values[theme] }
-
-    val t: Theme by loader
-
-    val textColor: Int
-        get() = t.textColorGetter(this)
-
-    val accentColor: Int
-        get() = t.accentColorGetter(this)
-
-    inline val accentColorForWhite: Int
-        get() = when {
-            accentColor.isColorVisibleOn(Color.WHITE) -> accentColor
-            textColor.isColorVisibleOn(Color.WHITE) -> textColor
-            else -> FACEBOOK_BLUE
-        }
-
-    inline val nativeBgColor: Int
-        get() = bgColor.withAlpha(30)
-
-    fun nativeBgColor(unread: Boolean) = bgColor
-        .colorToForeground(if (unread) 0.7f else 0.0f)
-        .withAlpha(30)
-
-    val bgColor: Int
-        get() = t.backgroundColorGetter(this)
-
-    val headerColor: Int
-        get() = t.headerColorGetter(this)
-
-    val iconColor: Int
-        get() = t.iconColorGetter(this)
-
-    val themeInjector: InjectorContract
-        get() = t.injector
-
-    val isCustomTheme: Boolean
-        get() = t == Theme.CUSTOM
-
-    inline val frostId: String
-        get() = "$installDate-$identifier"
-
-    var tintNavBar: Boolean by kpref("tint_nav_bar", true)
-
-    var webTextScaling: Int by kpref("web_text_scaling", 100)
-
-    var feedSort: Int by kpref("feed_sort", FeedSort.DEFAULT.ordinal)
-
-    var aggressiveRecents: Boolean by kpref("aggressive_recents", false)
-
-    var showComposer: Boolean by kpref("status_composer_feed", true)
-
-    var showSuggestedFriends: Boolean by kpref("suggested_friends_feed", true)
-
-    var showSuggestedGroups: Boolean by kpref("suggested_groups_feed", true)
-
-    var showFacebookAds: Boolean by kpref("facebook_ads", false)
-
-    var showStories: Boolean by kpref("show_stories", true)
-
-    var animate: Boolean by kpref("fancy_animations", true)
-
-    var notificationKeywords: Set<String> by kpref("notification_keywords", mutableSetOf())
-
-    var notificationsGeneral: Boolean by kpref("notification_general", true)
-
-    var notificationAllAccounts: Boolean by kpref("notification_all_accounts", true)
-
-    var notificationsInstantMessages: Boolean by kpref("notification_im", true)
-
-    var notificationsImAllAccounts: Boolean by kpref("notification_im_all_accounts", false)
-
-    var notificationVibrate: Boolean by kpref("notification_vibrate", true)
-
-    var notificationSound: Boolean by kpref("notification_sound", true)
-
-    var notificationRingtone: String by kpref("notification_ringtone", "")
-
-    var messageRingtone: String by kpref("message_ringtone", "")
-
-    var notificationLights: Boolean by kpref("notification_lights", true)
-
-    var messageScrollToBottom: Boolean by kpref("message_scroll_to_bottom", false)
-
-    var enablePip: Boolean by kpref("enable_pip", true)
-
-    /**
-     * Despite the naming, this toggle currently only enables debug logging.
-     * Verbose is never logged in release builds.
-     */
-    var verboseLogging: Boolean by kpref("verbose_logging", false)
-
-    var analytics: Boolean by kpref("analytics", false) {
-//        if (!BuildConfig.DEBUG) {
-//            if (it) {
-//                Bugsnag.setAutoCaptureSessions(true)
-//                Bugsnag.enableExceptionHandler()
-//            } else {
-//                Bugsnag.setAutoCaptureSessions(false)
-//                Bugsnag.disableExceptionHandler()
-//            }
-//        }
-    }
-
-    var biometricsEnabled: Boolean by kpref("biometrics_enabled", false)
-
-    var overlayEnabled: Boolean by kpref("overlay_enabled", true)
-
-    var overlayFullScreenSwipe: Boolean by kpref("overlay_full_screen_swipe", true)
-
-    var viewpagerSwipe: Boolean by kpref("viewpager_swipe", true)
-
-    var loadMediaOnMeteredNetwork: Boolean by kpref("media_on_metered_network", true)
-
-    var debugSettings: Boolean by kpref("debug_settings", false)
-
-    var linksInDefaultApp: Boolean by kpref("link_in_default_app", false)
-
-    var mainActivityLayoutType: Int by kpref("main_activity_layout_type", 0)
-
-    var blackMediaBg: Boolean by kpref("black_media_bg", false)
-
-    var autoRefreshFeed: Boolean by kpref("auto_refresh_feed", false)
-
-    var showCreateFab: Boolean by kpref("show_create_fab", true)
-
-    var fullSizeImage: Boolean by kpref("full_size_image", false)
-
-    inline val mainActivityLayout: MainActivityLayout
-        get() = MainActivityLayout(mainActivityLayoutType)
-
+interface Prefs : BehaviourPrefs, CorePrefs, FeedPrefs, NotifPrefs, ThemePrefs {
     companion object {
         fun get(): Prefs = KoinContextHandler.get().get()
 
         fun module() = module {
-            single { Prefs(get()) }
+            single<BehaviourPrefs> { BehaviourPrefsImpl(factory = get()) }
+            single<CorePrefs> { CorePrefsImpl(factory = get()) }
+            single<FeedPrefs> { FeedPrefsImpl(factory = get()) }
+            single<NotifPrefs> { NotifPrefsImpl(factory = get()) }
+            single<ThemePrefs> { ThemePrefsImpl(factory = get()) }
+            single<Prefs> {
+                PrefsImpl(
+                    behaviourPrefs = get(),
+                    corePrefs = get(),
+                    feedPrefs = get(),
+                    notifPrefs = get(),
+                    themePrefs = get()
+                )
+            }
+            // Needed for migration
+            single<OldPrefs> { OldPrefs(factory = get()) }
         }
     }
 }
+
+class PrefsImpl(
+    behaviourPrefs: BehaviourPrefs,
+    corePrefs: CorePrefs,
+    feedPrefs: FeedPrefs,
+    notifPrefs: NotifPrefs,
+    themePrefs: ThemePrefs
+) : Prefs,
+    BehaviourPrefs by behaviourPrefs,
+    CorePrefs by corePrefs,
+    FeedPrefs by feedPrefs,
+    NotifPrefs by notifPrefs,
+    ThemePrefs by themePrefs

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/Prefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/Prefs.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.pitchedapps.frost.utils
+package com.pitchedapps.frost.prefs
 
 import android.graphics.Color
 import ca.allanwang.kau.kotlin.lazyResettable

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/Prefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/Prefs.kt
@@ -24,12 +24,29 @@ import com.pitchedapps.frost.prefs.sections.FeedPrefs
 import com.pitchedapps.frost.prefs.sections.FeedPrefsImpl
 import com.pitchedapps.frost.prefs.sections.NotifPrefs
 import com.pitchedapps.frost.prefs.sections.NotifPrefsImpl
+import com.pitchedapps.frost.prefs.sections.ShowcasePrefs
+import com.pitchedapps.frost.prefs.sections.ShowcasePrefsImpl
 import com.pitchedapps.frost.prefs.sections.ThemePrefs
 import com.pitchedapps.frost.prefs.sections.ThemePrefsImpl
 import org.koin.core.context.KoinContextHandler
 import org.koin.dsl.module
 
-interface Prefs : BehaviourPrefs, CorePrefs, FeedPrefs, NotifPrefs, ThemePrefs {
+/**
+ * [Prefs] is no longer an actual pref, but we will expose the reset function as it is used elsewhere
+ */
+interface PrefsBase {
+    fun reset()
+    fun deleteKeys(vararg keys: String)
+}
+
+interface Prefs :
+    BehaviourPrefs,
+    CorePrefs,
+    FeedPrefs,
+    NotifPrefs,
+    ThemePrefs,
+    ShowcasePrefs,
+    PrefsBase {
     companion object {
         fun get(): Prefs = KoinContextHandler.get().get()
 
@@ -39,13 +56,15 @@ interface Prefs : BehaviourPrefs, CorePrefs, FeedPrefs, NotifPrefs, ThemePrefs {
             single<FeedPrefs> { FeedPrefsImpl(factory = get()) }
             single<NotifPrefs> { NotifPrefsImpl(factory = get()) }
             single<ThemePrefs> { ThemePrefsImpl(factory = get()) }
+            single<ShowcasePrefs> { ShowcasePrefsImpl(factory = get()) }
             single<Prefs> {
                 PrefsImpl(
                     behaviourPrefs = get(),
                     corePrefs = get(),
                     feedPrefs = get(),
                     notifPrefs = get(),
-                    themePrefs = get()
+                    themePrefs = get(),
+                    showcasePrefs = get()
                 )
             }
             // Needed for migration
@@ -55,14 +74,35 @@ interface Prefs : BehaviourPrefs, CorePrefs, FeedPrefs, NotifPrefs, ThemePrefs {
 }
 
 class PrefsImpl(
-    behaviourPrefs: BehaviourPrefs,
-    corePrefs: CorePrefs,
-    feedPrefs: FeedPrefs,
-    notifPrefs: NotifPrefs,
-    themePrefs: ThemePrefs
+    private val behaviourPrefs: BehaviourPrefs,
+    private val corePrefs: CorePrefs,
+    private val feedPrefs: FeedPrefs,
+    private val notifPrefs: NotifPrefs,
+    private val themePrefs: ThemePrefs,
+    private val showcasePrefs: ShowcasePrefs
 ) : Prefs,
     BehaviourPrefs by behaviourPrefs,
     CorePrefs by corePrefs,
     FeedPrefs by feedPrefs,
     NotifPrefs by notifPrefs,
-    ThemePrefs by themePrefs
+    ThemePrefs by themePrefs,
+    ShowcasePrefs by showcasePrefs {
+
+    override fun reset() {
+        behaviourPrefs.reset()
+        corePrefs.reset()
+        feedPrefs.reset()
+        notifPrefs.reset()
+        themePrefs.reset()
+        showcasePrefs.reset()
+    }
+
+    override fun deleteKeys(vararg keys: String) {
+        behaviourPrefs.deleteKeys()
+        corePrefs.deleteKeys()
+        feedPrefs.deleteKeys()
+        notifPrefs.deleteKeys()
+        themePrefs.deleteKeys()
+        showcasePrefs.deleteKeys()
+    }
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Allan Wang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.pitchedapps.frost.prefs.sections
+
+import ca.allanwang.kau.kpref.KPref
+import ca.allanwang.kau.kpref.KPrefFactory
+import com.pitchedapps.frost.BuildConfig
+import com.pitchedapps.frost.prefs.OldPrefs
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+interface BehaviourPrefs {
+    var biometricsEnabled: Boolean
+
+    var overlayEnabled: Boolean
+
+    var overlayFullScreenSwipe: Boolean
+
+    var viewpagerSwipe: Boolean
+
+    var loadMediaOnMeteredNetwork: Boolean
+
+    var debugSettings: Boolean
+
+    var linksInDefaultApp: Boolean
+
+    var blackMediaBg: Boolean
+
+    var autoRefreshFeed: Boolean
+
+    var showCreateFab: Boolean
+
+    var fullSizeImage: Boolean
+}
+
+class BehaviourPrefsImpl(
+    factory: KPrefFactory
+) : KPref("${BuildConfig.APPLICATION_ID}.prefs.behaviour", factory),
+    BehaviourPrefs, KoinComponent {
+
+    private val oldPrefs: OldPrefs by inject()
+
+    override var biometricsEnabled: Boolean by kpref(
+        "biometrics_enabled",
+        oldPrefs.biometricsEnabled /* false */
+    )
+
+    override var overlayEnabled: Boolean by kpref(
+        "overlay_enabled",
+        oldPrefs.overlayEnabled /* true */
+    )
+
+    override var overlayFullScreenSwipe: Boolean by kpref(
+        "overlay_full_screen_swipe",
+        oldPrefs.overlayFullScreenSwipe /* true */
+    )
+
+    override var viewpagerSwipe: Boolean by kpref(
+        "viewpager_swipe",
+        oldPrefs.viewpagerSwipe /* true */
+    )
+
+    override var loadMediaOnMeteredNetwork: Boolean by kpref(
+        "media_on_metered_network",
+        oldPrefs.loadMediaOnMeteredNetwork /* true */
+    )
+
+    override var debugSettings: Boolean by kpref(
+        "debug_settings",
+        oldPrefs.debugSettings /* false */
+    )
+
+    override var linksInDefaultApp: Boolean by kpref(
+        "link_in_default_app",
+        oldPrefs.linksInDefaultApp /* false */
+    )
+
+    override var blackMediaBg: Boolean by kpref("black_media_bg", oldPrefs.blackMediaBg /* false */)
+
+    override var autoRefreshFeed: Boolean by kpref(
+        "auto_refresh_feed",
+        oldPrefs.autoRefreshFeed /* false */
+    )
+
+    override var showCreateFab: Boolean by kpref(
+        "show_create_fab",
+        oldPrefs.showCreateFab /* true */
+    )
+
+    override var fullSizeImage: Boolean by kpref(
+        "full_size_image",
+        oldPrefs.fullSizeImage /* false */
+    )
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
@@ -106,5 +106,4 @@ class BehaviourPrefsImpl(
         "full_size_image",
         oldPrefs.fullSizeImage /* false */
     )
-
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
@@ -20,10 +20,11 @@ import ca.allanwang.kau.kpref.KPref
 import ca.allanwang.kau.kpref.KPrefFactory
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.prefs.OldPrefs
+import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface BehaviourPrefs {
+interface BehaviourPrefs : PrefsBase {
     var biometricsEnabled: Boolean
 
     var overlayEnabled: Boolean
@@ -105,4 +106,5 @@ class BehaviourPrefsImpl(
         "full_size_image",
         oldPrefs.fullSizeImage /* false */
     )
+
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/CorePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/CorePrefs.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Allan Wang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.pitchedapps.frost.prefs.sections
+
+import ca.allanwang.kau.kpref.KPref
+import ca.allanwang.kau.kpref.KPrefFactory
+import com.pitchedapps.frost.BuildConfig
+import com.pitchedapps.frost.prefs.OldPrefs
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+interface CorePrefs {
+    var lastLaunch: Long
+
+    var userId: Long
+
+    var prevId: Long
+
+    val frostId: String
+
+    var versionCode: Int
+
+    var prevVersionCode: Int
+
+    var installDate: Long
+
+    var identifier: Int
+
+    /**
+     * Despite the naming, this toggle currently only enables debug logging.
+     * Verbose is never logged in release builds.
+     */
+    var verboseLogging: Boolean
+
+    /**
+     * True to enable analytic reports (BugSnag)
+     */
+    var analytics: Boolean
+
+    var enablePip: Boolean
+
+    var exitConfirmation: Boolean
+
+    var animate: Boolean
+
+    var messageScrollToBottom: Boolean
+}
+
+class CorePrefsImpl(
+    factory: KPrefFactory
+) : KPref("${BuildConfig.APPLICATION_ID}.prefs.core", factory),
+    CorePrefs, KoinComponent {
+
+    private val oldPrefs: OldPrefs by inject()
+
+    override var lastLaunch: Long by kpref("last_launch", oldPrefs.lastLaunch /* -1L */)
+
+    override var userId: Long by kpref("user_id", oldPrefs.userId /* -1L */)
+
+    override var prevId: Long by kpref("prev_id", oldPrefs.prevId /* -1L */)
+
+    override val frostId: String
+        get() = "$installDate-$identifier"
+
+    override var versionCode: Int by kpref("version_code", oldPrefs.versionCode /* -1 */)
+
+    override var prevVersionCode: Int by kpref(
+        "prev_version_code",
+        oldPrefs.prevVersionCode /* -1 */
+    )
+
+    override var installDate: Long by kpref("install_date", oldPrefs.installDate /* -1L */)
+
+    override var identifier: Int by kpref("identifier", oldPrefs.identifier /* -1 */)
+
+    override var verboseLogging: Boolean by kpref(
+        "verbose_logging",
+        oldPrefs.verboseLogging /* false */
+    )
+
+    override var analytics: Boolean by kpref("analytics", oldPrefs.analytics /* false */) {
+//        if (!BuildConfig.DEBUG) {
+//            if (it) {
+//                Bugsnag.setAutoCaptureSessions(true)
+//                Bugsnag.enableExceptionHandler()
+//            } else {
+//                Bugsnag.setAutoCaptureSessions(false)
+//                Bugsnag.disableExceptionHandler()
+//            }
+//        }
+    }
+
+    override var enablePip: Boolean by kpref("enable_pip", oldPrefs.enablePip /* true */)
+
+    override var exitConfirmation: Boolean by kpref(
+        "exit_confirmation",
+        oldPrefs.exitConfirmation /* true */
+    )
+
+    override var animate: Boolean by kpref("fancy_animations", oldPrefs.animate /* true */)
+
+    override var messageScrollToBottom: Boolean by kpref(
+        "message_scroll_to_bottom",
+        oldPrefs.messageScrollToBottom /* false */
+    )
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/CorePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/CorePrefs.kt
@@ -24,7 +24,7 @@ import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface CorePrefs  : PrefsBase {
+interface CorePrefs : PrefsBase {
     var lastLaunch: Long
 
     var userId: Long

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/CorePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/CorePrefs.kt
@@ -20,10 +20,11 @@ import ca.allanwang.kau.kpref.KPref
 import ca.allanwang.kau.kpref.KPrefFactory
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.prefs.OldPrefs
+import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface CorePrefs {
+interface CorePrefs  : PrefsBase {
     var lastLaunch: Long
 
     var userId: Long

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/FeedPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/FeedPrefs.kt
@@ -21,10 +21,11 @@ import ca.allanwang.kau.kpref.KPrefFactory
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.enums.MainActivityLayout
 import com.pitchedapps.frost.prefs.OldPrefs
+import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface FeedPrefs {
+interface FeedPrefs : PrefsBase {
     var webTextScaling: Int
 
     var feedSort: Int

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/FeedPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/FeedPrefs.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Allan Wang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.pitchedapps.frost.prefs.sections
+
+import ca.allanwang.kau.kpref.KPref
+import ca.allanwang.kau.kpref.KPrefFactory
+import com.pitchedapps.frost.BuildConfig
+import com.pitchedapps.frost.enums.MainActivityLayout
+import com.pitchedapps.frost.prefs.OldPrefs
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+interface FeedPrefs {
+    var webTextScaling: Int
+
+    var feedSort: Int
+
+    var aggressiveRecents: Boolean
+
+    var showComposer: Boolean
+
+    var showSuggestedFriends: Boolean
+
+    var showSuggestedGroups: Boolean
+
+    var showFacebookAds: Boolean
+
+    var showStories: Boolean
+
+    var mainActivityLayoutType: Int
+
+    val mainActivityLayout: MainActivityLayout
+}
+
+class FeedPrefsImpl(
+    factory: KPrefFactory
+) : KPref("${BuildConfig.APPLICATION_ID}.prefs.feed", factory),
+    FeedPrefs, KoinComponent {
+
+    private val oldPrefs: OldPrefs by inject()
+
+    override var webTextScaling: Int by kpref("web_text_scaling", oldPrefs.webTextScaling /* 100 */)
+
+    override var feedSort: Int by kpref(
+        "feed_sort",
+        oldPrefs.feedSort /* FeedSort.DEFAULT.ordinal */
+    )
+
+    override var aggressiveRecents: Boolean by kpref(
+        "aggressive_recents",
+        oldPrefs.aggressiveRecents /* false */
+    )
+
+    override var showComposer: Boolean by kpref(
+        "status_composer_feed",
+        oldPrefs.showComposer /* true */
+    )
+
+    override var showSuggestedFriends: Boolean by kpref(
+        "suggested_friends_feed",
+        oldPrefs.showSuggestedFriends /* true */
+    )
+
+    override var showSuggestedGroups: Boolean by kpref(
+        "suggested_groups_feed",
+        oldPrefs.showSuggestedGroups /* true */
+    )
+
+    override var showFacebookAds: Boolean by kpref(
+        "facebook_ads",
+        oldPrefs.showFacebookAds /* false */
+    )
+
+    override var showStories: Boolean by kpref("show_stories", oldPrefs.showStories /* true */)
+
+    override var mainActivityLayoutType: Int by kpref(
+        "main_activity_layout_type",
+        oldPrefs.mainActivityLayoutType /* 0 */
+    )
+
+    override val mainActivityLayout: MainActivityLayout
+        get() = MainActivityLayout(mainActivityLayoutType)
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/NotifPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/NotifPrefs.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Allan Wang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.pitchedapps.frost.prefs.sections
+
+import ca.allanwang.kau.kpref.KPref
+import ca.allanwang.kau.kpref.KPrefFactory
+import com.pitchedapps.frost.BuildConfig
+import com.pitchedapps.frost.prefs.OldPrefs
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+interface NotifPrefs {
+    var notificationKeywords: Set<String>
+
+    var notificationsGeneral: Boolean
+
+    var notificationAllAccounts: Boolean
+
+    var notificationsInstantMessages: Boolean
+
+    var notificationsImAllAccounts: Boolean
+
+    var notificationVibrate: Boolean
+
+    var notificationSound: Boolean
+
+    var notificationRingtone: String
+
+    var messageRingtone: String
+
+    var notificationLights: Boolean
+
+    var notificationFreq: Long
+}
+
+class NotifPrefsImpl(
+    factory: KPrefFactory
+) : KPref("${BuildConfig.APPLICATION_ID}.prefs.notif", factory),
+    NotifPrefs, KoinComponent {
+
+    private val oldPrefs: OldPrefs by inject()
+
+    override var notificationKeywords: Set<String> by kpref(
+        "notification_keywords",
+        oldPrefs.notificationKeywords /* mutableSetOf() */
+    )
+
+    override var notificationsGeneral: Boolean by kpref(
+        "notification_general",
+        oldPrefs.notificationsGeneral /* true */
+    )
+
+    override var notificationAllAccounts: Boolean by kpref(
+        "notification_all_accounts",
+        oldPrefs.notificationAllAccounts /* true */
+    )
+
+    override var notificationsInstantMessages: Boolean by kpref(
+        "notification_im",
+        oldPrefs.notificationsInstantMessages /* true */
+    )
+
+    override var notificationsImAllAccounts: Boolean by kpref(
+        "notification_im_all_accounts",
+        oldPrefs.notificationsImAllAccounts /* false */
+    )
+
+    override var notificationVibrate: Boolean by kpref(
+        "notification_vibrate",
+        oldPrefs.notificationVibrate /* true */
+    )
+
+    override var notificationSound: Boolean by kpref(
+        "notification_sound",
+        oldPrefs.notificationSound /* true */
+    )
+
+    override var notificationRingtone: String by kpref(
+        "notification_ringtone",
+        oldPrefs.notificationRingtone /* "" */
+    )
+
+    override var messageRingtone: String by kpref(
+        "message_ringtone",
+        oldPrefs.messageRingtone /* "" */
+    )
+
+    override var notificationLights: Boolean by kpref(
+        "notification_lights",
+        oldPrefs.notificationLights /* true */
+    )
+
+    override var notificationFreq: Long by kpref(
+        "notification_freq",
+        oldPrefs.notificationFreq /* 15L */
+    )
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/NotifPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/NotifPrefs.kt
@@ -24,7 +24,7 @@ import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface NotifPrefs  : PrefsBase {
+interface NotifPrefs : PrefsBase {
     var notificationKeywords: Set<String>
 
     var notificationsGeneral: Boolean

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/NotifPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/NotifPrefs.kt
@@ -20,10 +20,11 @@ import ca.allanwang.kau.kpref.KPref
 import ca.allanwang.kau.kpref.KPrefFactory
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.prefs.OldPrefs
+import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface NotifPrefs {
+interface NotifPrefs  : PrefsBase {
     var notificationKeywords: Set<String>
 
     var notificationsGeneral: Boolean

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ShowcasePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ShowcasePrefs.kt
@@ -14,28 +14,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.pitchedapps.frost.utils
+package com.pitchedapps.frost.prefs.sections
 
 import ca.allanwang.kau.kpref.KPref
 import ca.allanwang.kau.kpref.KPrefFactory
 import com.pitchedapps.frost.BuildConfig
-import org.koin.dsl.module
+import com.pitchedapps.frost.prefs.PrefsBase
+
+interface ShowcasePrefs : PrefsBase {
+    /**
+     * Check if this is the first time launching the web overlay; show snackbar if true
+     */
+    val firstWebOverlay: Boolean
+
+    val intro: Boolean
+}
 
 /**
  * Created by Allan Wang on 2017-07-03.
  *
  * Showcase prefs that offer one time helpers to guide new users
  */
-class Showcase(factory: KPrefFactory) : KPref("${BuildConfig.APPLICATION_ID}.showcase", factory) {
+class ShowcasePrefsImpl(
+    factory: KPrefFactory
+) : KPref("${BuildConfig.APPLICATION_ID}.showcase", factory),
+    ShowcasePrefs {
 
-    // check if this is the first time launching the web overlay; show snackbar if true
-    val firstWebOverlay: Boolean by kprefSingle("first_web_overlay")
+    override val firstWebOverlay: Boolean by kprefSingle("first_web_overlay")
 
-    val intro: Boolean by kprefSingle("intro_pages")
-
-    companion object {
-        fun module() = module {
-            single { Showcase(get()) }
-        }
-    }
+    override val intro: Boolean by kprefSingle("intro_pages")
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ThemePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ThemePrefs.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Allan Wang
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.pitchedapps.frost.prefs.sections
+
+import android.graphics.Color
+import ca.allanwang.kau.kotlin.lazyResettable
+import ca.allanwang.kau.kpref.KPref
+import ca.allanwang.kau.kpref.KPrefFactory
+import ca.allanwang.kau.utils.colorToForeground
+import ca.allanwang.kau.utils.isColorVisibleOn
+import ca.allanwang.kau.utils.withAlpha
+import com.pitchedapps.frost.BuildConfig
+import com.pitchedapps.frost.enums.FACEBOOK_BLUE
+import com.pitchedapps.frost.enums.Theme
+import com.pitchedapps.frost.injectors.InjectorContract
+import com.pitchedapps.frost.prefs.OldPrefs
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+interface ThemePrefs {
+    var theme: Int
+
+    var customTextColor: Int
+
+    var customAccentColor: Int
+
+    var customBackgroundColor: Int
+
+    var customHeaderColor: Int
+
+    var customIconColor: Int
+
+    val textColor: Int
+
+    val accentColor: Int
+
+    val accentColorForWhite: Int
+
+    val nativeBgColor: Int
+
+    fun nativeBgColor(unread: Boolean): Int
+
+    val bgColor: Int
+
+    val headerColor: Int
+
+    val iconColor: Int
+
+    val themeInjector: InjectorContract
+
+    val isCustomTheme: Boolean
+
+    var tintNavBar: Boolean
+}
+
+class ThemePrefsImpl(
+    factory: KPrefFactory
+) : KPref("${BuildConfig.APPLICATION_ID}.prefs.theme", factory),
+    ThemePrefs, KoinComponent {
+
+    private val oldPrefs: OldPrefs by inject()
+
+    override var theme: Int by kpref("theme", oldPrefs.theme /* 0 */) { _: Int ->
+        loader.invalidate()
+    }
+
+    override var customTextColor: Int by kpref(
+        "color_text",
+        oldPrefs.customTextColor /* 0xffeceff1.toInt() */
+    )
+
+    override var customAccentColor: Int by kpref(
+        "color_accent",
+        oldPrefs.customAccentColor /* 0xff0288d1.toInt() */
+    )
+
+    override var customBackgroundColor: Int by kpref(
+        "color_bg",
+        oldPrefs.customBackgroundColor /* 0xff212121.toInt() */
+    )
+
+    override var customHeaderColor: Int by kpref(
+        "color_header",
+        oldPrefs.customHeaderColor /* 0xff01579b.toInt() */
+    )
+
+    override var customIconColor: Int by kpref(
+        "color_icons",
+        oldPrefs.customIconColor /* 0xffeceff1.toInt() */
+    )
+
+    private val loader = lazyResettable { Theme.values[theme] }
+
+    private val t: Theme by loader
+
+    override val textColor: Int
+        get() = t.textColorGetter(this)
+
+    override val accentColor: Int
+        get() = t.accentColorGetter(this)
+
+    override val accentColorForWhite: Int
+        get() = when {
+            accentColor.isColorVisibleOn(Color.WHITE) -> accentColor
+            textColor.isColorVisibleOn(Color.WHITE) -> textColor
+            else -> FACEBOOK_BLUE
+        }
+
+    override val nativeBgColor: Int
+        get() = bgColor.withAlpha(30)
+
+    override fun nativeBgColor(unread: Boolean) = bgColor
+        .colorToForeground(if (unread) 0.7f else 0.0f)
+        .withAlpha(30)
+
+    override val bgColor: Int
+        get() = t.backgroundColorGetter(this)
+
+    override val headerColor: Int
+        get() = t.headerColorGetter(this)
+
+    override val iconColor: Int
+        get() = t.iconColorGetter(this)
+
+    override val themeInjector: InjectorContract
+        get() = t.injector
+
+    override val isCustomTheme: Boolean
+        get() = t == Theme.CUSTOM
+
+    override var tintNavBar: Boolean by kpref("tint_nav_bar", oldPrefs.tintNavBar /* true */)
+}

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ThemePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ThemePrefs.kt
@@ -32,7 +32,7 @@ import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface ThemePrefs  : PrefsBase {
+interface ThemePrefs : PrefsBase {
     var theme: Int
 
     var customTextColor: Int

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ThemePrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/ThemePrefs.kt
@@ -28,10 +28,11 @@ import com.pitchedapps.frost.enums.FACEBOOK_BLUE
 import com.pitchedapps.frost.enums.Theme
 import com.pitchedapps.frost.injectors.InjectorContract
 import com.pitchedapps.frost.prefs.OldPrefs
+import com.pitchedapps.frost.prefs.PrefsBase
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-interface ThemePrefs {
+interface ThemePrefs  : PrefsBase {
     var theme: Int
 
     var customTextColor: Int

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
@@ -44,6 +44,7 @@ import com.pitchedapps.frost.facebook.parsers.ParseNotification
 import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.settings.hasNotifications
 import com.pitchedapps.frost.utils.ARG_USER_ID
 import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.frostEvent

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
@@ -43,10 +43,9 @@ import com.pitchedapps.frost.facebook.parsers.NotifParser
 import com.pitchedapps.frost.facebook.parsers.ParseNotification
 import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
-import com.pitchedapps.frost.settings.hasNotifications
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.ARG_USER_ID
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.frostEvent
 import com.pitchedapps.frost.utils.isIndependent
 import java.util.Locale

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/FrostNotifications.kt
@@ -46,7 +46,7 @@ import com.pitchedapps.frost.glide.GlideApp
 import com.pitchedapps.frost.settings.hasNotifications
 import com.pitchedapps.frost.utils.ARG_USER_ID
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.frostEvent
 import com.pitchedapps.frost.utils.isIndependent
 import java.util.Locale

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationService.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationService.kt
@@ -26,7 +26,7 @@ import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.db.NotificationDao
 import com.pitchedapps.frost.db.selectAll
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.frostEvent
 import com.pitchedapps.frost.widgets.NotificationWidget
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationService.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationService.kt
@@ -25,8 +25,8 @@ import com.pitchedapps.frost.db.CookieDao
 import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.db.NotificationDao
 import com.pitchedapps.frost.db.selectAll
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.frostEvent
 import com.pitchedapps.frost.widgets.NotificationWidget
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationUtils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationUtils.kt
@@ -31,8 +31,8 @@ import androidx.core.app.NotificationCompat
 import ca.allanwang.kau.utils.color
 import ca.allanwang.kau.utils.string
 import com.pitchedapps.frost.R
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.frostUri
 
 /**

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationUtils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/NotificationUtils.kt
@@ -32,7 +32,7 @@ import ca.allanwang.kau.utils.color
 import ca.allanwang.kau.utils.string
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.frostUri
 
 /**

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/UpdateReceiver.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/UpdateReceiver.kt
@@ -20,7 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/services/UpdateReceiver.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/services/UpdateReceiver.kt
@@ -19,8 +19,8 @@ package com.pitchedapps.frost.services
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/settings/Notifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/settings/Notifications.kt
@@ -33,8 +33,8 @@ import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.SettingsActivity
 import com.pitchedapps.frost.db.deleteAll
-import com.pitchedapps.frost.services.fetchNotifications
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.services.fetchNotifications
 import com.pitchedapps.frost.utils.REQUEST_NOTIFICATION
 import com.pitchedapps.frost.utils.frostSnackbar
 import com.pitchedapps.frost.utils.frostUri

--- a/app/src/main/kotlin/com/pitchedapps/frost/settings/Notifications.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/settings/Notifications.kt
@@ -34,7 +34,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.SettingsActivity
 import com.pitchedapps.frost.db.deleteAll
 import com.pitchedapps.frost.services.fetchNotifications
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.REQUEST_NOTIFICATION
 import com.pitchedapps.frost.utils.frostSnackbar
 import com.pitchedapps.frost.utils.frostUri

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/BiometricUtils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/BiometricUtils.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import ca.allanwang.kau.utils.string
 import com.pitchedapps.frost.R
+import com.pitchedapps.frost.prefs.Prefs
 import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Const.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Const.kt
@@ -20,6 +20,7 @@ package com.pitchedapps.frost.utils
  * Created by Allan Wang on 20/12/17.
  */
 const val ACTIVITY_SETTINGS = 97
+
 /*
  * Possible responses from the SettingsActivity
  * after the configurations have changed.

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
@@ -397,7 +397,10 @@ fun Context.frostUri(entry: String): Uri {
     return uri
 }
 
-inline fun Context.sendFrostEmail(@StringRes subjectId: Int, crossinline builder: EmailBuilder.() -> Unit) =
+inline fun Context.sendFrostEmail(
+    @StringRes subjectId: Int,
+    crossinline builder: EmailBuilder.() -> Unit
+) =
     sendFrostEmail(string(subjectId), builder)
 
 inline fun Context.sendFrostEmail(subjectId: String, crossinline builder: EmailBuilder.() -> Unit) =

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
@@ -69,6 +69,7 @@ import com.pitchedapps.frost.facebook.formattedFbUri
 import com.pitchedapps.frost.facebook.formattedFbUrl
 import com.pitchedapps.frost.injectors.CssAssets
 import com.pitchedapps.frost.injectors.JsAssets
+import com.pitchedapps.frost.prefs.Prefs
 import java.io.File
 import java.io.IOException
 import java.net.URLEncoder

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/WebContextMenu.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/WebContextMenu.kt
@@ -27,6 +27,7 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.activities.MainActivity
 import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.facebook.formattedFbUrl
+import com.pitchedapps.frost.prefs.Prefs
 
 /**
  * Created by Allan Wang on 2017-07-07.

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/AccountItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/AccountItem.kt
@@ -37,7 +37,7 @@ import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.facebook.profilePictureUrl
 import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/BadgedIcon.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/BadgedIcon.kt
@@ -29,7 +29,7 @@ import ca.allanwang.kau.utils.visible
 import ca.allanwang.kau.utils.withAlpha
 import com.mikepenz.iconics.typeface.IIcon
 import com.pitchedapps.frost.databinding.ViewBadgedIconBinding
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostContentView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostContentView.kt
@@ -41,7 +41,7 @@ import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.WEB_LOAD_DELAY
 import com.pitchedapps.frost.kotlin.subscribeDuringJob
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostContentView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostContentView.kt
@@ -40,8 +40,8 @@ import com.pitchedapps.frost.contracts.FrostContentParent
 import com.pitchedapps.frost.facebook.FbItem
 import com.pitchedapps.frost.facebook.WEB_LOAD_DELAY
 import com.pitchedapps.frost.kotlin.subscribeDuringJob
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostRecyclerView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostRecyclerView.kt
@@ -27,7 +27,7 @@ import com.pitchedapps.frost.contracts.FrostContentContainer
 import com.pitchedapps.frost.contracts.FrostContentCore
 import com.pitchedapps.frost.contracts.FrostContentParent
 import com.pitchedapps.frost.fragments.RecyclerContentContract
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import org.koin.core.KoinComponent

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostVideoView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostVideoView.kt
@@ -172,6 +172,7 @@ class FrostVideoView @JvmOverloads constructor(
             // todo use provided ratio?
             val ratio =
                 min(width.toFloat() / intrinsicWidth, height.toFloat() / intrinsicHeight.toFloat())
+
             /**
              * Only remap if not expanded and if dimensions have changed
              */

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostVideoViewer.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostVideoViewer.kt
@@ -43,8 +43,8 @@ import com.pitchedapps.frost.R
 import com.pitchedapps.frost.databinding.ViewVideoBinding
 import com.pitchedapps.frost.db.CookieDao
 import com.pitchedapps.frost.db.currentCookie
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.ctxCoroutine
 import com.pitchedapps.frost.utils.frostDownload
 import org.koin.core.KoinComponent
@@ -218,6 +218,7 @@ class FrostVideoViewer @JvmOverloads constructor(
 
 interface FrostVideoViewerContract : VideoControlsVisibilityListener {
     fun onSingleTapConfirmed(event: MotionEvent): Boolean
+
     /**
      * Process of expansion
      * 1f represents an expanded view, 0f represents a minimized view

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostVideoViewer.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostVideoViewer.kt
@@ -44,7 +44,7 @@ import com.pitchedapps.frost.databinding.ViewVideoBinding
 import com.pitchedapps.frost.db.CookieDao
 import com.pitchedapps.frost.db.currentCookie
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.ctxCoroutine
 import com.pitchedapps.frost.utils.frostDownload
 import org.koin.core.KoinComponent

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostViewPager.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostViewPager.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
 import androidx.viewpager.widget.ViewPager
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
@@ -35,7 +35,7 @@ import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.facebook.USER_AGENT
 import com.pitchedapps.frost.fragments.WebFragment
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.ctxCoroutine
 import com.pitchedapps.frost.utils.frostDownload
 import com.pitchedapps.frost.web.FrostChromeClient

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
@@ -34,8 +34,8 @@ import com.pitchedapps.frost.facebook.FB_HOME_URL
 import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.facebook.USER_AGENT
 import com.pitchedapps.frost.fragments.WebFragment
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.ctxCoroutine
 import com.pitchedapps.frost.utils.frostDownload
 import com.pitchedapps.frost.web.FrostChromeClient

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/Keywords.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/Keywords.kt
@@ -37,7 +37,7 @@ import com.mikepenz.fastadapter.listeners.ClickEventHook
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.pitchedapps.frost.R
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/DebugWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/DebugWebView.kt
@@ -29,7 +29,7 @@ import com.pitchedapps.frost.injectors.CssHider
 import com.pitchedapps.frost.injectors.CssSmallAssets
 import com.pitchedapps.frost.injectors.jsInject
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.createFreshFile
 import com.pitchedapps.frost.utils.isFacebookUrl
 import java.io.File

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/DebugWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/DebugWebView.kt
@@ -28,8 +28,8 @@ import com.pitchedapps.frost.facebook.USER_AGENT
 import com.pitchedapps.frost.injectors.CssHider
 import com.pitchedapps.frost.injectors.CssSmallAssets
 import com.pitchedapps.frost.injectors.jsInject
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.createFreshFile
 import com.pitchedapps.frost.utils.isFacebookUrl
 import java.io.File

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
@@ -25,7 +25,7 @@ import com.pitchedapps.frost.contracts.VideoViewHolder
 import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.facebook.FbCookie
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.WebContext
 import com.pitchedapps.frost.utils.cookies
 import com.pitchedapps.frost.utils.ctxCoroutine

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
@@ -24,8 +24,8 @@ import com.pitchedapps.frost.contracts.MainActivityContract
 import com.pitchedapps.frost.contracts.VideoViewHolder
 import com.pitchedapps.frost.db.CookieEntity
 import com.pitchedapps.frost.facebook.FbCookie
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.WebContext
 import com.pitchedapps.frost.utils.cookies
 import com.pitchedapps.frost.utils.ctxCoroutine

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -33,8 +33,8 @@ import com.pitchedapps.frost.injectors.CssSmallAssets
 import com.pitchedapps.frost.injectors.JsActions
 import com.pitchedapps.frost.injectors.JsAssets
 import com.pitchedapps.frost.injectors.jsInject
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.isExplicitIntent
 import com.pitchedapps.frost.utils.isFacebookUrl
 import com.pitchedapps.frost.utils.isImageUrl
@@ -72,6 +72,7 @@ open class FrostWebViewClient(val web: FrostWebView) : BaseWebViewClient() {
     private val prefs: Prefs get() = web.prefs
     private val refresh: SendChannel<Boolean> = web.parent.refreshChannel
     private val isMain = web.parent.baseEnum != null
+
     /**
      * True if current url supports refresh. See [doUpdateVisitedHistory] for updates
      */

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -34,7 +34,7 @@ import com.pitchedapps.frost.injectors.JsActions
 import com.pitchedapps.frost.injectors.JsAssets
 import com.pitchedapps.frost.injectors.jsInject
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.isExplicitIntent
 import com.pitchedapps.frost.utils.isFacebookUrl
 import com.pitchedapps.frost.utils.isImageUrl

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/LoginWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/LoginWebView.kt
@@ -38,7 +38,7 @@ import com.pitchedapps.frost.facebook.get
 import com.pitchedapps.frost.injectors.CssHider
 import com.pitchedapps.frost.injectors.jsInject
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.isFacebookUrl
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.coroutineScope

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/LoginWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/LoginWebView.kt
@@ -37,8 +37,8 @@ import com.pitchedapps.frost.facebook.USER_AGENT
 import com.pitchedapps.frost.facebook.get
 import com.pitchedapps.frost.injectors.CssHider
 import com.pitchedapps.frost.injectors.jsInject
-import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.prefs.Prefs
+import com.pitchedapps.frost.utils.L
 import com.pitchedapps.frost.utils.isFacebookUrl
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.coroutineScope

--- a/app/src/main/kotlin/com/pitchedapps/frost/widgets/NotificationWidget.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/widgets/NotificationWidget.kt
@@ -45,7 +45,7 @@ import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
 import com.pitchedapps.frost.services.NotificationContent
 import com.pitchedapps.frost.services.NotificationType
-import com.pitchedapps.frost.utils.Prefs
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.toReadableTime
 import org.koin.core.KoinComponent
 import org.koin.core.inject

--- a/app/src/main/kotlin/com/pitchedapps/frost/widgets/NotificationWidget.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/widgets/NotificationWidget.kt
@@ -43,9 +43,9 @@ import com.pitchedapps.frost.db.NotificationDao
 import com.pitchedapps.frost.db.selectNotificationsSync
 import com.pitchedapps.frost.glide.FrostGlide
 import com.pitchedapps.frost.glide.GlideApp
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.services.NotificationContent
 import com.pitchedapps.frost.services.NotificationType
-import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.toReadableTime
 import org.koin.core.KoinComponent
 import org.koin.core.inject
@@ -114,7 +114,12 @@ private fun RemoteViews.setBackgroundColor(@IdRes viewId: Int, @ColorInt color: 
 /**
  * Adds backward compatibility to setting tinted icons
  */
-private fun RemoteViews.setIcon(@IdRes viewId: Int, context: Context, @DrawableRes res: Int, @ColorInt color: Int) {
+private fun RemoteViews.setIcon(
+    @IdRes viewId: Int,
+    context: Context,
+    @DrawableRes res: Int,
+    @ColorInt color: Int
+) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val icon =
             Icon.createWithResource(context, res).setTint(color).setTintMode(PorterDuff.Mode.SRC_IN)
@@ -154,6 +159,7 @@ class NotificationWidgetDataProvider(val context: Context, val intent: Intent) :
     private val prefs: Prefs by inject()
 
     private val notifDao: NotificationDao by inject()
+
     @Volatile
     private var content: List<NotificationContent> = emptyList()
 

--- a/app/src/test/kotlin/com/pitchedapps/frost/prefs/PrefsTest.kt
+++ b/app/src/test/kotlin/com/pitchedapps/frost/prefs/PrefsTest.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.pitchedapps.frost.utils
+package com.pitchedapps.frost.prefs
 
 import kotlin.test.assertEquals
 import org.junit.Before


### PR DESCRIPTION
Split preferences into multiple files to avoid large xml files.

Separation involved adding new interface segments, and creating a new `Prefs` interface that implements all segments. Prefs usage should not change as the interface holds all settings options.

For now, I will not add a check to migrate all settings over (as defaults are often left blank and should not be saved). Instead, I made the fallback for each segment point to the old preferences.

Replacement was done via

`override var (.*): (.*) by kpref\("(.*)", (.*)\)` &rarr;
`override var $1: $2 by kpref\("$3", oldPrefs.$1 /* $4 */ \)`