### PR TITLE
Disable context menu shortly after scrolling

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.withContext
  */
 enum class JsAssets(private val singleLoad: Boolean = true) : InjectorContract {
     MENU, CLICK_A, CONTEXT_A, MEDIA, HEADER_BADGES, TEXTAREA_LISTENER, NOTIF_MSG,
-    DOCUMENT_WATCHER, HORIZONTAL_SCROLLING, AUTO_RESIZE_TEXTAREA(singleLoad = false)
+    DOCUMENT_WATCHER, HORIZONTAL_SCROLLING, AUTO_RESIZE_TEXTAREA(singleLoad = false), SCROLL_STOP,
     ;
 
     @VisibleForTesting

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
@@ -166,7 +166,7 @@ class FrostJSI(val web: FrostWebView) {
 
     @JavascriptInterface
     fun setScrolling(scrolling: Boolean) {
-        L.i { "Scrolling $scrolling" }
+        L.v { "Scrolling $scrolling" }
         this.isScrolling = scrolling
     }
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
@@ -161,4 +161,15 @@ class FrostJSI(val web: FrostWebView) {
         activity?.contentBinding?.viewpager?.enableSwipe = enable
         (context as? WebOverlayActivityBase)?.swipeBack?.disallowIntercept = !enable
     }
+
+    private var isScrolling = false
+
+    @JavascriptInterface
+    fun setScrolling(scrolling: Boolean) {
+        L.i { "Scrolling $scrolling" }
+        this.isScrolling = scrolling
+    }
+
+    @JavascriptInterface
+    fun isScrolling(): Boolean = isScrolling
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -125,6 +125,7 @@ open class FrostWebViewClient(val web: FrostWebView) : BaseWebViewClient() {
             JsAssets.CLICK_A,
             JsAssets.CONTEXT_A,
             JsAssets.MEDIA,
+            JsAssets.SCROLL_STOP,
             prefs = prefs
         )
     }

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -6,6 +6,13 @@
     <item text="" />
     -->
 
+    <version title="v2.4.7" />
+    <item text="Fix theme not always sticking on refresh" />
+    <item text="Disable long press menu from appearing immediately after scrolling" />
+    <item text="" />
+    <item text="" />
+    <item text="" />
+
     <version title="v2.4.6" />
     <item text="Add option to hide likes and action bar in newsfeed" />
     <item text="Fix textbox scroll position when typing multiple lines" />

--- a/app/src/web/ts/context_a.ts
+++ b/app/src/web/ts/context_a.ts
@@ -110,6 +110,14 @@
         Frost.longClick(true);
         longClick = true;
 
+        /**
+         * Don't handle context events while scrolling
+         */
+        if (Frost.isScrolling()) {
+            console.log("Skip from scrolling");
+            return;
+        }
+
         /*
          * Commonality; check for valid target
          */

--- a/app/src/web/ts/scroll_stop.ts
+++ b/app/src/web/ts/scroll_stop.ts
@@ -1,0 +1,25 @@
+// Listen when scrolling events stop
+(function () {
+    let scrollTimeout: number | undefined = undefined;
+    let scrolling: boolean = false;
+
+    window.addEventListener('scroll', function (event) {
+
+        if (!scrolling) {
+            Frost.setScrolling(true);
+            scrolling = true;
+        }
+
+        window.clearTimeout(scrollTimeout);
+
+        scrollTimeout = setTimeout(function () {
+            if (scrolling) {
+                Frost.setScrolling(false);
+                scrolling = false;
+            }
+        }, 600);
+        // For our specific use case, we want to release other features pretty far after scrolling stops
+        // For general scrolling use cases, the delta can be much smaller
+        // My assumption for context menus is that the long press is 500ms
+    }, false);
+}).call(undefined);

--- a/app/src/web/typings/frost.d.ts
+++ b/app/src/web/typings/frost.d.ts
@@ -24,6 +24,10 @@ declare interface FrostJSI {
   handleHeader(html: string | null)
 
   allowHorizontalScrolling(enable: boolean)
+
+  setScrolling(scrolling: boolean)
+
+  isScrolling(): boolean
 }
 
 declare var Frost: FrostJSI;


### PR DESCRIPTION
Kind of. We check for the flag only after the context click is registered, so we must assume scrolling at least after [duration of long press] ms after scrolling stops. My assumption is that the value is 500 ms, or also that people will take at least 100 ms to go from stopped scroll to long press. Value can be adjusted if necessary