### PR TITLE
Unfinished Messages to Messenger hack and return to "touch.$FACEBOOK_COM"

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbConst.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbConst.kt
@@ -23,13 +23,13 @@ package com.pitchedapps.frost.facebook
 const val FACEBOOK_COM = "facebook.com"
 const val FBCDN_NET = "fbcdn.net"
 const val WWW_FACEBOOK_COM = "www.$FACEBOOK_COM"
-const val FACEBOOK_BASE_COM = "m.$FACEBOOK_COM"
+const val FACEBOOK_BASE_COM = "touch.$FACEBOOK_COM"
 const val FB_URL_BASE = "https://$FACEBOOK_BASE_COM/"
 const val FACEBOOK_MBASIC_COM = "mbasic.$FACEBOOK_COM"
 const val FB_URL_MBASIC_BASE = "https://$FACEBOOK_MBASIC_COM/"
 fun profilePictureUrl(id: Long) = "https://graph.facebook.com/$id/picture?type=large"
 const val FB_LOGIN_URL = "${FB_URL_BASE}login"
-const val FB_HOME_URL = "${FB_URL_BASE}home.php"
+const val FB_HOME_URL = "https://messenger.com"
 
 /*
  * User agent candidates.

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
@@ -47,7 +47,7 @@ enum class FbItem(
     GROUPS(R.string.groups, GoogleMaterial.Icon.gmd_group, "groups"),
     MARKETPLACE(R.string.marketplace, GoogleMaterial.Icon.gmd_store, "marketplace"),
     MENU(R.string.menu, GoogleMaterial.Icon.gmd_menu, "settings"),
-    MESSAGES(R.string.messages, MaterialDesignIconic.Icon.gmi_comments, "messages"),
+    MESSAGES(R.string.messages, MaterialDesignIconic.Icon.gmi_comments, "messenger"),
     NOTES(R.string.notes, CommunityMaterial.Icon3.cmd_note, "notes"),
     NOTIFICATIONS(R.string.notifications, MaterialDesignIconic.Icon.gmi_globe, "notifications"),
     ON_THIS_DAY(R.string.on_this_day, GoogleMaterial.Icon.gmd_today, "onthisday"),
@@ -77,7 +77,7 @@ enum class FbItem(
     SETTINGS(R.string.settings, GoogleMaterial.Icon.gmd_settings, "settings"),
     ;
 
-    val url = "$prefix$relativeUrl"
+    val url = if (relativeUrl != "messenger") "$prefix$relativeUrl" else "https://messenger.com"
 
     val isFeed: Boolean
         get() = when (this) {


### PR DESCRIPTION
I am trying to fix the [Messages from application stops working · Issue #1732 · AllanWang/Frost-for-Facebook](https://github.com/AllanWang/Frost-for-Facebook/issues/1732) issue. More contribution needed to toggle `document.getElementsByClassName('n5hh3s10')[0].style.display` on the messenger.com desktop version loaded into the WebView