### PR TITLE
Fix multi account switching

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
@@ -500,7 +500,7 @@ abstract class BaseMainActivity :
                                     )
                                     positiveButton(R.string.kau_yes) {
                                         this@BaseMainActivity.launch {
-                                            fbCookie.logout(this@BaseMainActivity)
+                                            fbCookie.logout(this@BaseMainActivity, deleteCookie = true)
                                         }
                                     }
                                     negativeButton(R.string.kau_no)

--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/SettingsActivity.kt
@@ -233,8 +233,8 @@ class SettingsActivity : KPrefActivity() {
 
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
-        activityThemer.setFrostTheme(forceTransparent = true)
         super.onCreate(savedInstanceState)
+        activityThemer.setFrostTheme(forceTransparent = true)
         animate = prefs.animate
         themeExterior(false)
     }

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbCookie.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbCookie.kt
@@ -48,8 +48,11 @@ class FbCookie @Inject internal constructor(
 ) {
 
     companion object {
-        private const val FB_COOKIE_DOMAIN = HTTPS_FACEBOOK_COM
-        private const val MESSENGER_COOKIE_DOMAIN = HTTPS_MESSENGER_COM
+        /**
+         * Domain information. Dot prefix still matters for Android browsers.
+         */
+        private const val FB_COOKIE_DOMAIN = ".$FACEBOOK_COM"
+        private const val MESSENGER_COOKIE_DOMAIN = ".$MESSENGER_COM"
     }
 
     /**
@@ -135,22 +138,24 @@ class FbCookie @Inject internal constructor(
      * Helper function to remove the current cookies
      * and launch the proper login page
      */
-    suspend fun logout(context: Context) {
+    suspend fun logout(context: Context, deleteCookie: Boolean = true) {
         val cookies = arrayListOf<CookieEntity>()
         if (context is Activity)
             cookies.addAll(context.cookies().filter { it.id != prefs.userId })
-        logout(prefs.userId)
+        logout(prefs.userId, deleteCookie)
         context.launchLogin(cookies, true)
     }
 
     /**
      * Clear the cookies of the given id
      */
-    suspend fun logout(id: Long) {
+    suspend fun logout(id: Long, deleteCookie: Boolean = true) {
         L.d { "Logging out user" }
-        cookieDao.deleteById(id)
-        L.d { "Fb cookie deleted" }
-        L._d { id }
+        if (deleteCookie) {
+            cookieDao.deleteById(id)
+            L.d { "Fb cookie deleted" }
+            L._d { id }
+        }
         reset()
     }
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
@@ -133,7 +133,7 @@ private inline fun <reified T : WebOverlayActivityBase> Context.launchWebOverlay
     if (argUrl.isFacebookUrl && argUrl.contains("/logout.php")) {
         L.d { "Logout php found" }
         ctxCoroutine.launch {
-            fbCookie.logout(this@launchWebOverlayImpl)
+            fbCookie.logout(this@launchWebOverlayImpl, deleteCookie = false)
         }
     } else if (!(prefs.linksInDefaultApp && resolveActivityForUri(Uri.parse(argUrl)))) {
         startActivity<T>(

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostJSI.kt
@@ -121,7 +121,7 @@ class FrostJSI(val web: FrostWebView) {
     fun loadLogin() {
         L.d { "Sign up button found; load login" }
         context.ctxCoroutine.launch {
-            fbCookie.logout(context)
+            fbCookie.logout(context, deleteCookie = false)
         }
     }
 

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -1,5 +1,4 @@
-v3.0.0
+v3.1.0
 
-* Removed email support. Please use GitHub for all inquiries as I no longer have time to look through all emails
-* Added initial support for messenger.com (settings > appearance > main activity tabs)
-* Fix swipe to refresh not disabling for certain pages
+* Fix multi account signin
+* Only clear out cookies on explicit logout; Facebook logout redirects no longer erase cookies

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -49,7 +49,7 @@
 
     <style name="FrostTheme.Video" parent="FrostTheme.Overlay.Fade" />
 
-    <style name="FrostTheme.Settings" parent="FrostTheme">
+    <style name="FrostTheme.Settings" parent="FrostTheme.Transparent">
         <item name="android:windowAnimationStyle">@style/KauSlideInFadeOut</item>
     </style>
 

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -6,13 +6,15 @@
     <item text="" />
     -->
 
+    <version title="v3.1.0" />
+    <item text="Fix multi account signin" />
+    <item text="Only clear out cookies on explicit logout; Facebook logout redirects no longer erase cookies" />
+    <item text="" />
+
     <version title="v3.0.0" />
     <item text="Removed email support. Please use GitHub for all inquiries as I no longer have time to look through all emails" />
     <item text="Added initial support for messenger.com (settings > appearance > main activity tabs)" />
     <item text="Fix swipe to refresh not disabling for certain pages" />
-    <item text="" />
-    <item text="" />
-    <item text="" />
 
     <version title="v2.4.7" />
     <item text="Fix theme not always sticking on refresh" />

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.0
+* Fix multi account signin
+* Only clear out cookies on explicit logout; Facebook logout redirects no longer erase cookies
+
 ## v3.0.0
 * Removed email support. Please use GitHub for all inquiries as I no longer have time to look through all emails
 * Added initial support for messenger.com (settings > appearance > main activity tabs)


### PR DESCRIPTION
Fixes #1753

Very simple change. Previously, the cookie was set to `https://www.facebook.com`, which worked. Now, it's set to `.facebook.com`. As far as I'm aware, cookie domains are not supposed to have protocols, so it was incorrect before. The `.` prefix is still necessary for Android, even if it's no longer the case for modern browsers.

https://stackoverflow.com/questions/9618217/what-does-the-dot-prefix-in-the-cookie-domain-mean