### PR TITLE
Hilt Fixes

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/BaseMainActivity.kt
@@ -24,14 +24,11 @@ import android.content.res.ColorStateList
 import android.graphics.PointF
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.RippleDrawable
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.webkit.ValueCallback
-import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ImageView
@@ -79,10 +76,9 @@ import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial
 import com.pitchedapps.frost.BuildConfig
 import com.pitchedapps.frost.R
-import com.pitchedapps.frost.contracts.FileChooserContract
-import com.pitchedapps.frost.contracts.FileChooserDelegate
 import com.pitchedapps.frost.contracts.MainActivityContract
 import com.pitchedapps.frost.contracts.VideoViewHolder
+import com.pitchedapps.frost.contracts.WebFileChooser
 import com.pitchedapps.frost.databinding.ActivityMainBinding
 import com.pitchedapps.frost.databinding.ActivityMainBottomTabsBinding
 import com.pitchedapps.frost.databinding.ActivityMainDrawerWrapperBinding
@@ -149,7 +145,6 @@ import kotlin.math.abs
 abstract class BaseMainActivity :
     BaseActivity(),
     MainActivityContract,
-    FileChooserContract by FileChooserDelegate(),
     VideoViewHolder,
     SearchViewHolder {
 
@@ -166,6 +161,9 @@ abstract class BaseMainActivity :
 
     @Inject
     lateinit var genericDao: GenericDao
+
+    @Inject
+    lateinit var webFileChooser: WebFileChooser
 
     interface ActivityMainContentBinding {
         val root: View
@@ -715,16 +713,9 @@ abstract class BaseMainActivity :
         return true
     }
 
-    override fun openFileChooser(
-        filePathCallback: ValueCallback<Array<Uri>?>,
-        fileChooserParams: WebChromeClient.FileChooserParams
-    ) {
-        openMediaPicker(filePathCallback, fileChooserParams)
-    }
-
     @SuppressLint("NewApi")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (onActivityResultWeb(requestCode, resultCode, data)) return
+        if (webFileChooser.onActivityResultWeb(requestCode, resultCode, data)) return
         super.onActivityResult(requestCode, resultCode, data)
 
         fun hasRequest(flag: Int) = resultCode and flag > 0

--- a/app/src/main/kotlin/com/pitchedapps/frost/contracts/ActivityContract.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/contracts/ActivityContract.kt
@@ -17,18 +17,12 @@
 package com.pitchedapps.frost.contracts
 
 import com.mikepenz.iconics.typeface.IIcon
-import com.pitchedapps.frost.activities.MainActivity
 import com.pitchedapps.frost.fragments.BaseFragment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BroadcastChannel
 
-/**
- * All the contracts for [MainActivity]
- */
-interface ActivityContract : FileChooserActivityContract
-
 @UseExperimental(ExperimentalCoroutinesApi::class)
-interface MainActivityContract : ActivityContract, MainFabContract {
+interface MainActivityContract : MainFabContract {
     val fragmentChannel: BroadcastChannel<Int>
     val headerBadgeChannel: BroadcastChannel<String>
     fun setTitle(res: Int)

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/FrostWebView.kt
@@ -29,6 +29,7 @@ import ca.allanwang.kau.utils.launchMain
 import com.pitchedapps.frost.contracts.FrostContentContainer
 import com.pitchedapps.frost.contracts.FrostContentCore
 import com.pitchedapps.frost.contracts.FrostContentParent
+import com.pitchedapps.frost.contracts.WebFileChooser
 import com.pitchedapps.frost.db.CookieDao
 import com.pitchedapps.frost.db.currentCookie
 import com.pitchedapps.frost.facebook.FB_HOME_URL
@@ -70,6 +71,9 @@ class FrostWebView @JvmOverloads constructor(
     lateinit var themeProvider: ThemeProvider
 
     @Inject
+    lateinit var webFileChooser: WebFileChooser
+
+    @Inject
     lateinit var cookieDao: CookieDao
 
     override fun reload(animate: Boolean) {
@@ -98,7 +102,7 @@ class FrostWebView @JvmOverloads constructor(
         // attempt to get custom client; otherwise fallback to original
         frostWebClient = (container as? WebFragment)?.client(this) ?: FrostWebViewClient(this)
         webViewClient = frostWebClient
-        webChromeClient = FrostChromeClient(this, themeProvider)
+        webChromeClient = FrostChromeClient(this, themeProvider, webFileChooser)
         addJavascriptInterface(FrostJSI(this), "Frost")
         setBackgroundColor(Color.TRANSPARENT)
         setDownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostChromeClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostChromeClients.kt
@@ -30,11 +30,9 @@ import ca.allanwang.kau.permissions.kauRequestPermissions
 import ca.allanwang.kau.utils.materialDialog
 import com.afollestad.materialdialogs.callbacks.onDismiss
 import com.afollestad.materialdialogs.input.input
-import com.pitchedapps.frost.R
-import com.pitchedapps.frost.contracts.ActivityContract
+import com.pitchedapps.frost.contracts.WebFileChooser
 import com.pitchedapps.frost.injectors.ThemeProvider
 import com.pitchedapps.frost.utils.L
-import com.pitchedapps.frost.utils.frostSnackbar
 import com.pitchedapps.frost.views.FrostWebView
 import kotlinx.coroutines.channels.SendChannel
 
@@ -49,13 +47,13 @@ import kotlinx.coroutines.channels.SendChannel
  */
 class FrostChromeClient(
     web: FrostWebView,
-    private val themeProvider: ThemeProvider
+    private val themeProvider: ThemeProvider,
+    private val webFileChooser: WebFileChooser,
 ) : WebChromeClient() {
 
     private val refresh: SendChannel<Boolean> = web.parent.refreshChannel
     private val progress: SendChannel<Int> = web.parent.progressChannel
     private val title: SendChannel<String> = web.parent.titleChannel
-    private val activity = (web.context as? ActivityContract)
     private val context = web.context!!
 
     override fun getDefaultVideoPoster(): Bitmap? =
@@ -83,9 +81,8 @@ class FrostChromeClient(
         filePathCallback: ValueCallback<Array<Uri>?>,
         fileChooserParams: FileChooserParams
     ): Boolean {
-        activity?.openFileChooser(filePathCallback, fileChooserParams)
-            ?: webView.frostSnackbar(R.string.file_chooser_not_found, themeProvider)
-        return activity != null
+        webFileChooser.openMediaPicker(filePathCallback, fileChooserParams)
+        return true
     }
 
     private fun JsResult.frostCancel() {

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -1,6 +1,3 @@
-v3.1.0
+v3.1.1
 
-* Fix multi account sign in
-* Only clear out cookies on explicit logout; Facebook logout redirects no longer erase cookies
-* Update themes
-* Big infra changes (please file bugs for new crashes)
+* Many internal fixes to address 3.1.0 issues

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -5,6 +5,11 @@
     <version title="v" />
     <item text="" />
     -->
+    <version title="v3.1.1" />
+    <item text="Many internal fixes to address 3.1.0 issues" />
+    <item text="" />
+    <item text="" />
+    <item text="" />
 
     <version title="v3.1.0" />
     <item text="Fix multi account sign in" />

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v3.1.1
+* Many internal fixes to address 3.1.0 issues
+
 ## v3.1.0
 * Fix multi account sign in
 * Only clear out cookies on explicit logout; Facebook logout redirects no longer erase cookies


### PR DESCRIPTION
Fixes #1806, #1808, #1814

With hilt, view contexts become context wrappers around underlying activities, making it less straightforward to extract activity interfaces. You can still do so by unwrapping wrappers, but an easier approach is to inject the activity context/activity and use it directly.

The following tries to remove some casting against activities