### PR TITLE
Support messenger usage when default apps are enabled

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,10 +35,10 @@ android {
         applicationId "${project.APP_GROUP}.${project.APP_ID.toLowerCase(Locale.CANADA)}"
         minSdkVersion kau.Versions.minSdk
         targetSdkVersion Versions.targetSdk
-        versionCode 3010100
-//        versionCode androidGitVersion.code()
-        versionName '3.1.1'
-//        versionName androidGitVersion.name()
+//        versionCode 3010100
+        versionCode androidGitVersion.code()
+//        versionName '3.1.1'
+        versionName androidGitVersion.name()
 
         if (System.getenv('CI') != 'true') {
             // Verification for F-Droid builds

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -130,6 +130,18 @@
                 <data
                     android:host="www.facebook.com"
                     android:scheme="https" />
+                <data
+                    android:host="messenger.com"
+                    android:scheme="http" />
+                <data
+                    android:host="messenger.com"
+                    android:scheme="https" />
+                <data
+                    android:host="www.messenger.com"
+                    android:scheme="http" />
+                <data
+                    android:host="www.messenger.com"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
@@ -307,14 +307,11 @@ fun Context.createPrivateMediaFile(extension: String) = createPrivateMediaFile("
 /**
  * Tries to send the uri to the proper activity via an intent
  * returns [true] if activity is resolved, [false] otherwise
- * For safety, any uri that [isFacebookUrl] without [isExplicitIntent] will return [false]
+ * For safety, any uri that ([isFacebookUrl] or [isMessengerUrl]) without [isExplicitIntent] will return [false]
  */
 fun Context.startActivityForUri(uri: Uri): Boolean {
     val url = uri.toString()
-    if (url.isFacebookUrl && !url.isExplicitIntent) {
-        return false
-    }
-    if (url.isMessengerUrl) {
+    if ((url.isFacebookUrl || url.isMessengerUrl) && !url.isExplicitIntent) {
         return false
     }
     val intent = Intent(

--- a/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/utils/Utils.kt
@@ -314,6 +314,9 @@ fun Context.startActivityForUri(uri: Uri): Boolean {
     if (url.isFacebookUrl && !url.isExplicitIntent) {
         return false
     }
+    if (url.isMessengerUrl) {
+        return false
+    }
     val intent = Intent(
         Intent.ACTION_VIEW,
         uri.formattedFbUri

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostUrlOverlayValidator.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostUrlOverlayValidator.kt
@@ -28,6 +28,7 @@ import com.pitchedapps.frost.utils.isFacebookUrl
 import com.pitchedapps.frost.utils.isImageUrl
 import com.pitchedapps.frost.utils.isIndependent
 import com.pitchedapps.frost.utils.isIndirectImageUrl
+import com.pitchedapps.frost.utils.isMessengerUrl
 import com.pitchedapps.frost.utils.isVideoUrl
 import com.pitchedapps.frost.utils.launchImageActivity
 import com.pitchedapps.frost.utils.launchWebOverlay
@@ -76,7 +77,7 @@ fun FrostWebView.requestWebOverlay(url: String): Boolean {
     }
     if (!prefs.overlayEnabled) return false
     if (context is WebOverlayActivityBase) {
-        val shouldUseDesktop = url.isFacebookUrl
+        val shouldUseDesktop = url.isFacebookUrl || url.isMessengerUrl
         // already overlay; manage user agent
         if (userAgentString != USER_AGENT_DESKTOP_CONST && shouldUseDesktop) {
             L._i { "Switch to desktop agent overlay" }


### PR DESCRIPTION
Fixes #1748 

Previously, messenger urls were not handled in Frost and are forwarded to other apps when default apps are selected. Now, they are handled internally and aren't forwarded.

From the issue, it sounds like forwarded urls don't work even if the messenger app is installed. Regardless, Facebook does not redirect to messenger's threads directly, so if you have the official app, you probably don't need messenger tabs.