### PR TITLE
Fix menu tab loading

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
@@ -46,7 +46,12 @@ enum class FbItem(
     FRIENDS(R.string.friends, GoogleMaterial.Icon.gmd_person_add, "friends/center/requests"),
     GROUPS(R.string.groups, GoogleMaterial.Icon.gmd_group, "groups"),
     MARKETPLACE(R.string.marketplace, GoogleMaterial.Icon.gmd_store, "marketplace"),
-    MENU(R.string.menu, GoogleMaterial.Icon.gmd_menu, "settings"),
+    /*
+     * Unlike other urls, menus cannot be linked directly as it is a soft reference. Instead, we can
+     * pick any url with the blue bar and manually click to enter the menu.
+     * The notifications page was picked arbitrarily as I assume it has the smallest loading footprint.
+     */
+    MENU(R.string.menu, GoogleMaterial.Icon.gmd_menu, "notifications.php"),
     MESSAGES(R.string.messages, MaterialDesignIconic.Icon.gmi_comments, "messages"),
     MESSENGER(R.string.messenger, CommunityMaterial.Icon2.cmd_facebook_messenger, "", prefix = HTTPS_MESSENGER_COM),
     NOTES(R.string.notes, CommunityMaterial.Icon3.cmd_note, "notes"),

--- a/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/facebook/FbItem.kt
@@ -46,14 +46,20 @@ enum class FbItem(
     FRIENDS(R.string.friends, GoogleMaterial.Icon.gmd_person_add, "friends/center/requests"),
     GROUPS(R.string.groups, GoogleMaterial.Icon.gmd_group, "groups"),
     MARKETPLACE(R.string.marketplace, GoogleMaterial.Icon.gmd_store, "marketplace"),
+
     /*
      * Unlike other urls, menus cannot be linked directly as it is a soft reference. Instead, we can
      * pick any url with the blue bar and manually click to enter the menu.
-     * The notifications page was picked arbitrarily as I assume it has the smallest loading footprint.
+     * We pick home.php as some back interactions default to home regardless of the base url.
      */
-    MENU(R.string.menu, GoogleMaterial.Icon.gmd_menu, "notifications.php"),
+    MENU(R.string.menu, GoogleMaterial.Icon.gmd_menu, "home.php"),
     MESSAGES(R.string.messages, MaterialDesignIconic.Icon.gmi_comments, "messages"),
-    MESSENGER(R.string.messenger, CommunityMaterial.Icon2.cmd_facebook_messenger, "", prefix = HTTPS_MESSENGER_COM),
+    MESSENGER(
+        R.string.messenger,
+        CommunityMaterial.Icon2.cmd_facebook_messenger,
+        "",
+        prefix = HTTPS_MESSENGER_COM
+    ),
     NOTES(R.string.notes, CommunityMaterial.Icon3.cmd_note, "notes"),
     NOTIFICATIONS(R.string.notifications, MaterialDesignIconic.Icon.gmi_globe, "notifications"),
     ON_THIS_DAY(R.string.on_this_day, GoogleMaterial.Icon.gmd_today, "onthisday"),

--- a/app/src/main/kotlin/com/pitchedapps/frost/fragments/WebFragments.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/fragments/WebFragments.kt
@@ -61,20 +61,4 @@ class WebFragment : BaseFragment() {
         }
         super.updateFab(contract)
     }
-
-    override fun onBackPressed(): Boolean {
-        if (baseEnum == FbItem.MENU) {
-            val core = core
-            val web = core as? WebView
-            if (web != null && web.canGoBack() && !web.canGoBackOrForward(-2)) {
-                // If menu item + we are at the second last entry, reload the base
-                // To properly inflate the menu
-                // Related to https://github.com/AllanWang/Frost-for-Facebook/issues/1593
-                core.clearHistory()
-                core.reloadBase(true)
-                return true
-            }
-        }
-        return super.onBackPressed()
-    }
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAsset.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAsset.kt
@@ -26,9 +26,9 @@ enum class CssAsset(private val content: String) : InjectorContract {
     FullSizeImage("div._4prr[style*=\"max-width\"][style*=\"max-height\"]{max-width:none !important;max-height:none !important}"),
 
     /*
-     * Remove top margin and hide some contents from the top bar and notification page (as it's our base url)
+     * Remove top margin and hide some contents from the top bar and home page (as it's our base url)
      */
-    Menu("#bookmarks_flyout{margin-top:0 !important}#notifications_list{display:none !important}")
+    Menu("#bookmarks_flyout{margin-top:0 !important}#m_news_feed_stream,#MComposer{display:none !important}")
     ;
 
     val injector: JsInjector by lazy {

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAsset.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/CssAsset.kt
@@ -23,7 +23,12 @@ import com.pitchedapps.frost.prefs.Prefs
  * Small misc inline css assets
  */
 enum class CssAsset(private val content: String) : InjectorContract {
-    FullSizeImage("div._4prr[style*=\"max-width\"][style*=\"max-height\"]{max-width:none !important;max-height:none !important}")
+    FullSizeImage("div._4prr[style*=\"max-width\"][style*=\"max-height\"]{max-width:none !important;max-height:none !important}"),
+
+    /*
+     * Remove top margin and hide some contents from the top bar and notification page (as it's our base url)
+     */
+    Menu("#bookmarks_flyout{margin-top:0 !important}#notifications_list{display:none !important}")
     ;
 
     val injector: JsInjector by lazy {

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsAssets.kt
@@ -34,7 +34,7 @@ import java.util.Locale
  * The enum name must match the css file name
  */
 enum class JsAssets(private val singleLoad: Boolean = true) : InjectorContract {
-    MENU, CLICK_A, CONTEXT_A, MEDIA, HEADER_BADGES, TEXTAREA_LISTENER, NOTIF_MSG,
+    MENU, MENU_QUICK(singleLoad = false), CLICK_A, CONTEXT_A, MEDIA, HEADER_BADGES, TEXTAREA_LISTENER, NOTIF_MSG,
     DOCUMENT_WATCHER, HORIZONTAL_SCROLLING, AUTO_RESIZE_TEXTAREA(singleLoad = false), SCROLL_STOP,
     ;
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/injectors/JsInjector.kt
@@ -97,7 +97,7 @@ interface InjectorContract {
  * Helper method to inject multiple functions simultaneously with a single callback
  */
 fun WebView.jsInject(vararg injectors: InjectorContract, prefs: Prefs) {
-    injectors.filter { it != JsActions.EMPTY }.forEach {
+    injectors.asSequence().filter { it != JsActions.EMPTY }.forEach {
         it.inject(this, prefs)
     }
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -302,7 +302,7 @@ class FrostWebViewClientMenu(web: FrostWebView) : FrostWebViewClient(web) {
      * Instead, we remove the flyout margins within the js script so that it covers the header.
      */
     override val facebookJsInjectors: List<InjectorContract> =
-        super.facebookJsInjectors - CssHider.HEADER
+        super.facebookJsInjectors - CssHider.HEADER + CssAsset.Menu
 
     override fun emit(flag: Int) {
         super.emit(flag)
@@ -310,6 +310,17 @@ class FrostWebViewClientMenu(web: FrostWebView) : FrostWebViewClient(web) {
             EMIT_FINISH -> {
                 super.injectAndFinish()
             }
+        }
+    }
+
+    /*
+     * Facebook doesn't properly load back to the menu even in standard browsers.
+     * Instead, if we detect the base soft url, we will manually click the menu item
+     */
+    override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
+        super.doUpdateVisitedHistory(view, url, isReload)
+        if (url?.startsWith(FbItem.MENU.url) == true) {
+            jsInject(JsAssets.MENU_QUICK, prefs = prefs)
         }
     }
 

--- a/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/web/FrostWebViewClients.kt
@@ -135,7 +135,7 @@ open class FrostWebViewClient(val web: FrostWebView) : BaseWebViewClient() {
         JsAssets.DOCUMENT_WATCHER,
         JsAssets.HORIZONTAL_SCROLLING,
         JsAssets.AUTO_RESIZE_TEXTAREA.maybe(prefs.autoExpandTextBox),
-//            JsAssets.CLICK_A,
+        JsAssets.CLICK_A,
         JsAssets.CONTEXT_A,
         JsAssets.MEDIA,
         JsAssets.SCROLL_STOP,

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -1,3 +1,4 @@
 v3.1.2
 
 * Fix loading full size images
+* Fix menu tab

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -8,7 +8,7 @@
 
     <version title="v3.1.2" />
     <item text="Fix loading full size images" />
-    <item text="" />
+    <item text="Fix menu tab" />
     <item text="" />
 
     <version title="v3.1.1" />

--- a/app/src/web/ts/menu.ts
+++ b/app/src/web/ts/menu.ts
@@ -20,43 +20,19 @@
         return
     }
 
-    /*
-     * Required to remove height restrictions
-     */
-    const y = new MutationObserver(() => {
-        viewport.removeAttribute('style');
-        root.removeAttribute('style');
-    });
+    // menu container
+    const bookmarkFlyout = document.querySelector('#bookmarks_flyout');
+    if (bookmarkFlyout instanceof HTMLElement) {
+        bookmarkFlyout.style.marginTop = "0";
+    }
 
-    y.observe(viewport, {
-        attributes: true
-    });
-    y.observe(root, {
-        attributes: true
-    });
-
-    const x = new MutationObserver(() => {
-        const menu = document.querySelector('.mSideMenu');
-        if (menu) {
-            x.disconnect();
-            console.log("Found side menu");
-            // Transfer elements
-            while (root.firstChild) {
-                root.removeChild(root.firstChild);
-            }
-            while (menu.childNodes.length) {
-                viewport.appendChild(menu.childNodes[0]);
-            }
+    // Js handling is a bit slow so we need to wait 
+    setTimeout(() => {
+        menuA.click();
+        console.log("Menu setup clicked");
+        // Reaction is also slow so we need to wait
+        setTimeout(() => {
             Frost.emit(0);
-            setTimeout(() => {
-                y.disconnect();
-                console.log('Unhook styler');
-            }, 500);
-        }
-    });
-    x.observe(jewel, {
-        childList: true,
-        subtree: true
-    });
-    menuA.click();
+        }, 100);
+    }, 200);
 }).call(undefined);

--- a/app/src/web/ts/menu_quick.ts
+++ b/app/src/web/ts/menu_quick.ts
@@ -1,4 +1,4 @@
-// Click menu after delay and notify
+// Copy of menu.ts without timeouts or notifications
 (function () {
     const viewport = document.querySelector("#viewport");
     const root = document.querySelector("#root");
@@ -20,13 +20,5 @@
         return
     }
 
-    // Js handling is a bit slow so we need to wait 
-    setTimeout(() => {
-        menuA.click();
-        console.log("Menu setup clicked");
-        // Reaction is also slow so we need to wait
-        setTimeout(() => {
-            Frost.emit(0);
-        }, 100);
-    }, 500);
+    menuA.click();
 }).call(undefined);

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v3.1.2
 * Fix loading full size images
+* Fix menu tab
 
 ## v3.1.1
 * Many internal fixes to address 3.1.0 issues


### PR DESCRIPTION
Loading error fix:

`/settings` no longer showed the blue bar, so we update the base url

---

Button interaction fix:

As part of a general fix, I've also changed how the menu item is loaded. As it contains a soft url, it cannot be loaded directly like other fbitems. Originally, I'd manually click the menu item. As this populates a flyout container which is inside the blue bar that we hide, I'd move the elements out, restyle them, and then show the page.

The flyout ended up having a higher elevation, so I've mitigated the movement by simply removing its top margin. The blue bar can be seen slightly afterwards, but the logic is simplified and it supports the "see all apps" button, which was previously broken (#1764). The script now redirects to the menu as soon as the pseudo base url is detected, which adds better back button support for elements that can't open in new screens