### PR TITLE
Add option to disable swipe to refresh

### DIFF
--- a/app/src/main/kotlin/com/pitchedapps/frost/activities/WebOverlayActivity.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/activities/WebOverlayActivity.kt
@@ -298,6 +298,7 @@ abstract class WebOverlayActivityBase(private val userAgent: String = USER_AGENT
   override fun onOptionsItemSelected(item: MenuItem): Boolean {
     val url = web.currentUrl.formattedFbUrl
     when (item.itemId) {
+      R.id.action_refresh -> web.reload(animate = true)
       R.id.action_copy_link -> copyToClipboard(url)
       R.id.action_share -> shareText(url)
       R.id.action_open_in_browser -> startLink(url)

--- a/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/prefs/sections/BehaviourPrefs.kt
@@ -32,6 +32,8 @@ interface BehaviourPrefs : PrefsBase {
 
   var viewpagerSwipe: Boolean
 
+  var swipeToRefresh: Boolean
+
   var loadMediaOnMeteredNetwork: Boolean
 
   var debugSettings: Boolean
@@ -57,34 +59,60 @@ internal constructor(
 ) : KPref("${BuildConfig.APPLICATION_ID}.prefs.behaviour", factory), BehaviourPrefs {
 
   override var biometricsEnabled: Boolean by
-    kpref("biometrics_enabled", oldPrefs.biometricsEnabled /* false */)
+    kpref(
+      "biometrics_enabled",
+      oldPrefs.biometricsEnabled, /* false */
+    )
 
   override var overlayEnabled: Boolean by
-    kpref("overlay_enabled", oldPrefs.overlayEnabled /* true */)
+    kpref(
+      "overlay_enabled",
+      oldPrefs.overlayEnabled, /* true */
+    )
 
   override var overlayFullScreenSwipe: Boolean by
-    kpref("overlay_full_screen_swipe", oldPrefs.overlayFullScreenSwipe /* true */)
+    kpref(
+      "overlay_full_screen_swipe",
+      oldPrefs.overlayFullScreenSwipe, /* true */
+    )
 
   override var viewpagerSwipe: Boolean by
-    kpref("viewpager_swipe", oldPrefs.viewpagerSwipe /* true */)
+    kpref(
+      "viewpager_swipe",
+      oldPrefs.viewpagerSwipe, /* true */
+    )
+
+  override var swipeToRefresh: Boolean by kpref("swipe_to_refresh", true)
 
   override var loadMediaOnMeteredNetwork: Boolean by
-    kpref("media_on_metered_network", oldPrefs.loadMediaOnMeteredNetwork /* true */)
+    kpref(
+      "media_on_metered_network",
+      oldPrefs.loadMediaOnMeteredNetwork, /* true */
+    )
 
   override var debugSettings: Boolean by kpref("debug_settings", oldPrefs.debugSettings /* false */)
 
   override var linksInDefaultApp: Boolean by
-    kpref("link_in_default_app", oldPrefs.linksInDefaultApp /* false */)
+    kpref(
+      "link_in_default_app",
+      oldPrefs.linksInDefaultApp, /* false */
+    )
 
   override var blackMediaBg: Boolean by kpref("black_media_bg", oldPrefs.blackMediaBg /* false */)
 
   override var autoRefreshFeed: Boolean by
-    kpref("auto_refresh_feed", oldPrefs.autoRefreshFeed /* false */)
+    kpref(
+      "auto_refresh_feed",
+      oldPrefs.autoRefreshFeed, /* false */
+    )
 
   override var showCreateFab: Boolean by kpref("show_create_fab", oldPrefs.showCreateFab /* true */)
 
   override var fullSizeImage: Boolean by
-    kpref("full_size_image", oldPrefs.fullSizeImage /* false */)
+    kpref(
+      "full_size_image",
+      oldPrefs.fullSizeImage, /* false */
+    )
 
   override var autoExpandTextBox: Boolean by kpref("auto_expand_text_box", true)
 }

--- a/app/src/main/kotlin/com/pitchedapps/frost/settings/Behaviour.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/settings/Behaviour.kt
@@ -68,6 +68,10 @@ fun SettingsActivity.getBehaviourPrefs(): KPrefAdapterBuilder.() -> Unit = {
     descRes = R.string.viewpager_swipe_desc
   }
 
+  checkbox(R.string.swipe_to_refresh, prefs::swipeToRefresh, { prefs.swipeToRefresh = it }) {
+    descRes = R.string.swipe_to_refresh_desc
+  }
+
   checkbox(
     R.string.force_message_bottom,
     prefs::messageScrollToBottom,

--- a/app/src/main/kotlin/com/pitchedapps/frost/views/SwipeRefreshLayout.kt
+++ b/app/src/main/kotlin/com/pitchedapps/frost/views/SwipeRefreshLayout.kt
@@ -26,14 +26,20 @@ import android.widget.ListView
 import androidx.core.widget.ListViewCompat
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnChildScrollUpCallback
+import com.pitchedapps.frost.prefs.Prefs
 import com.pitchedapps.frost.utils.L
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 /**
  * Variant that forbids refreshing if child layout is not at the top Inspired by
  * https://github.com/slapperwan/gh4a/blob/master/app/src/main/java/com/gh4a/widget/SwipeRefreshLayout.java
  */
+@AndroidEntryPoint
 class SwipeRefreshLayout @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
   SwipeRefreshLayout(context, attrs) {
+
+  @Inject lateinit var prefs: Prefs
 
   private var preventRefresh: Boolean = false
   private var downY: Float = -1f
@@ -61,6 +67,9 @@ class SwipeRefreshLayout @JvmOverloads constructor(context: Context, attrs: Attr
   }
 
   override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+    if (!prefs.swipeToRefresh) {
+      return false
+    }
     if (ev.action != MotionEvent.ACTION_DOWN && preventRefresh) {
       return false
     }
@@ -77,6 +86,10 @@ class SwipeRefreshLayout @JvmOverloads constructor(context: Context, attrs: Attr
       }
     }
     return super.onInterceptTouchEvent(ev)
+  }
+
+  override fun onStartNestedScroll(child: View, target: View, nestedScrollAxes: Int): Boolean {
+    return prefs.swipeToRefresh && super.onStartNestedScroll(child, target, nestedScrollAxes)
   }
 
   override fun onNestedScroll(

--- a/app/src/main/play/en-US/whatsnew
+++ b/app/src/main/play/en-US/whatsnew
@@ -3,3 +3,4 @@ v3.2.0
 * Improve loading process
 * Add option to hide recommended for you posts
 * Fix menu tab loading
+* Add option to disable swipe to refresh (settings > behaviour)

--- a/app/src/main/res/menu/menu_web.xml
+++ b/app/src/main/res/menu/menu_web.xml
@@ -4,6 +4,11 @@
     tools:context="com.pitchedapps.frost.activities.WebOverlayActivity">
 
     <item
+        android:id="@+id/action_refresh"
+        android:title="@string/refresh"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_copy_link"
         android:title="@string/copy_link"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings_pref_behaviour.xml
+++ b/app/src/main/res/values/strings_pref_behaviour.xml
@@ -13,6 +13,8 @@
     <string name="open_links_in_default_desc">When possible, open links in the default app rather than through the Frost web overlay</string>
     <string name="viewpager_swipe">Viewpager Swipe</string>
     <string name="viewpager_swipe_desc">Allow swiping between the pages in the main view to switch tabs. By default, the swiping automatically stops when you long press on an item, such as the like button. Disabling this will prevent page swiping altogether.</string>
+    <string name="swipe_to_refresh">Swipe to Refresh</string>
+    <string name="swipe_to_refresh_desc">Allow swiping down to refresh</string>
     <string name="search_bar">Search Bar</string>
     <string name="search_bar_desc">Enable the search bar instead of a search overlay</string>
     <string name="force_message_bottom">Force Message Bottom</string>

--- a/app/src/main/res/values/strings_web_context.xml
+++ b/app/src/main/res/values/strings_web_context.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <string name="refresh">Refresh</string>
     <string name="share_link">Share Link</string>
     <string name="local_service_name" translatable="false">Local Frost Service</string>
     <string name="open_link">Open Link</string>

--- a/app/src/main/res/xml/frost_changelog.xml
+++ b/app/src/main/res/xml/frost_changelog.xml
@@ -10,7 +10,7 @@
     <item text="Improve loading process" />
     <item text="Add option to hide recommended for you posts" />
     <item text="Fix menu tab loading" />
-    <item text="" />
+    <item text="Add option to disable swipe to refresh (settings > behaviour)" />
     <item text="" />
     <item text="" />
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,7 @@
 * Improve loading process
 * Add option to hide recommended for you posts
 * Fix menu tab loading
+* Add option to disable swipe to refresh (settings > behaviour)
 
 ## v3.1.2
 * Fix loading full size images


### PR DESCRIPTION
Fixes #1864

This is patched for now. If Frost ends up being rewritten with compose, I may remove swipe to refresh entirely